### PR TITLE
Fix CDC clock lifetime parameters

### DIFF
--- a/crates/skalp-frontend/src/lexer.rs
+++ b/crates/skalp-frontend/src/lexer.rs
@@ -542,9 +542,12 @@ pub enum Token {
     SizedLiteral(u64),
 
     // Lifetime token - 'identifier for clock domain lifetimes
-    // This pattern now only matches when the char after ' is alphabetic (not bhd followed by digits)
+    // First regex: lifetimes NOT starting with b/h/d (e.g., 'src, 'a, 'clk)
     #[regex(r"'[a-zA-Z_&&[^bhd]][a-zA-Z0-9_]*", |lex| lex.slice()[1..].to_owned())]
-    #[regex(r"'[bhd][a-zA-Z_][a-zA-Z0-9_]*", |lex| lex.slice()[1..].to_owned())]
+    // Second regex: lifetimes starting with b/h/d (e.g., 'dst, 'd, 'bus)
+    // These need special handling to avoid conflict with sized literals (8'hFF, 4'd15).
+    // Sized literals always start with digits before the ', so standalone 'b/'h/'d are safe.
+    #[regex(r"'[bhd][a-zA-Z0-9_]*", |lex| lex.slice()[1..].to_owned())]
     Lifetime(String),
 
     // Whitespace and comments (skipped but tracked for position)

--- a/crates/skalp-frontend/src/parse.rs
+++ b/crates/skalp-frontend/src/parse.rs
@@ -4049,6 +4049,12 @@ impl<'a> ParseState<'a> {
                 self.finish_node();
             }
         }
+        // Lifetime parameter (e.g., 'src, 'dst in Synchronizer<'src, 'dst>)
+        else if self.at(SyntaxKind::Lifetime) {
+            self.start_node(SyntaxKind::IdentExpr);
+            self.bump();
+            self.finish_node();
+        }
         // Otherwise parse as type
         else {
             self.parse_type();
@@ -4418,6 +4424,12 @@ impl<'a> ParseState<'a> {
                 self.bump(); // '('
                 self.parse_type_arg_expr();
                 self.expect(SyntaxKind::RParen);
+                self.finish_node();
+            }
+            Some(SyntaxKind::Lifetime) => {
+                // Lifetime in type argument context (e.g., clock<'dst>, bit<'src>)
+                self.start_node(SyntaxKind::IdentExpr);
+                self.bump(); // consume lifetime token
                 self.finish_node();
             }
             _ => {


### PR DESCRIPTION
## Summary
- Fix lexer regex to tokenize single-char lifetimes `'b`, `'h`, `'d` (previously only multi-char lifetimes like `'dst` worked due to overly restrictive regex to avoid sized literal conflicts)
- Add `Lifetime` token handling in `parse_type_arg_primary()` and `parse_type_or_const_arg()` so `bit<'src>`, `clock<'dst>`, and entity generics like `Synchronizer<'src, 'dst>` parse correctly
- Without parser fix, unhandled Lifetime tokens caused infinite loops in struct field parsing

## Test plan
- [ ] `synchronizer.sk` compiles (was parse error before)
- [ ] `uart_dual_clock.sk` compiles (was hanging before)
- [ ] All existing tests pass (CI)
- [ ] `pub struct S<'d> { f: bit<'d> }` compiles (was hanging due to lexer bug)

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5