### PR TITLE
Fix multi-entity elaboration bugs (Issue #14)

### DIFF
--- a/crates/skalp-frontend/src/hir_builder.rs
+++ b/crates/skalp-frontend/src/hir_builder.rs
@@ -3702,6 +3702,7 @@ impl HirBuilderContext {
                 expr.kind()
             );
         }
+
         let rhs = if rhs_start_idx >= exprs.len() {
             return None;
         } else if rhs_start_idx == exprs.len() - 1 {
@@ -8547,7 +8548,7 @@ impl HirBuilderContext {
             })
             .collect();
 
-        // If we have both IdentExpr and IndexExpr, use the IndexExpr (it's the complete expression)
+        // If we have both IdentExpr and IndexExpr/FieldExpr, use the last one (it's the complete expression)
         let operand_node = if expr_children.len() > 1 {
             // Check if last is IndexExpr and previous is IdentExpr/FieldExpr/PathExpr
             if expr_children
@@ -8559,6 +8560,21 @@ impl HirBuilderContext {
                     SyntaxKind::IdentExpr | SyntaxKind::FieldExpr | SyntaxKind::PathExpr
                 )
             {
+                expr_children.last()?
+            } else if expr_children
+                .last()
+                .is_some_and(|n| n.kind() == SyntaxKind::FieldExpr)
+                && expr_children.len() >= 2
+                && matches!(
+                    expr_children[expr_children.len() - 2].kind(),
+                    SyntaxKind::IdentExpr | SyntaxKind::PathExpr | SyntaxKind::FieldExpr
+                )
+            {
+                // BUG #85 FIX: Handle field access on entity instances inside unary expressions.
+                // For `!tx_fifo.empty`, the parser creates UnaryExpr with children:
+                //   [IdentExpr(tx_fifo), FieldExpr(.empty)]
+                // Use the FieldExpr — build_field_expr will look up the preceding sibling
+                // IdentExpr to construct the proper FieldAccess expression.
                 expr_children.last()?
             } else {
                 expr_children.first()?

--- a/crates/skalp-mir/src/hir_to_mir.rs
+++ b/crates/skalp-mir/src/hir_to_mir.rs
@@ -1218,6 +1218,7 @@ impl<'hir> HirToMir<'hir> {
                             hir_instance.name,
                             hir_instance.entity
                         );
+
                         // Find the entity to get its output ports
                         if let Some(entity) = self
                             .hir
@@ -4615,89 +4616,17 @@ impl<'hir> HirToMir<'hir> {
                     format!("variable_{}", id.0)
                 }
                 hir::HirLValue::Range(base, ..) => {
-                    format!("range[base={:?}]", std::mem::discriminant(&**base))
+                    format!("range[base={}]", Self::describe_hir_lvalue(base))
                 }
                 hir::HirLValue::FieldAccess { base, field } => {
-                    format!(
-                        "field_access[base={:?}.{}]",
-                        std::mem::discriminant(&**base),
-                        field
-                    )
+                    format!("{}.{}", Self::describe_hir_lvalue(base), field)
                 }
                 hir::HirLValue::Index(base, ..) => {
-                    format!("index[base={:?}]", std::mem::discriminant(&**base))
+                    format!("index[base={}]", Self::describe_hir_lvalue(base))
                 }
             };
 
-            let rhs_desc = match &assign.rhs {
-                hir::HirExpression::Call(call) => {
-                    format!(
-                        "function call to '{}' with {} arguments",
-                        call.function,
-                        call.args.len()
-                    )
-                }
-                hir::HirExpression::Cast(cast) => {
-                    format!(
-                        "Cast(inner={:?}, target={:?})",
-                        std::mem::discriminant(&*cast.expr),
-                        cast.target_type
-                    )
-                }
-                hir::HirExpression::Match(match_expr) => {
-                    // BUG #234 DEBUG: Show match expression details
-                    let arm_descs: Vec<String> = match_expr
-                        .arms
-                        .iter()
-                        .enumerate()
-                        .map(|(i, arm)| {
-                            format!(
-                                "  arm[{}]: pattern={:?}, expr_type={:?}",
-                                i,
-                                arm.pattern,
-                                std::mem::discriminant(&arm.expr)
-                            )
-                        })
-                        .collect();
-                    format!(
-                        "Match expression with {} arms, scrutinee={:?}:\n{}",
-                        match_expr.arms.len(),
-                        std::mem::discriminant(&*match_expr.expr),
-                        arm_descs.join("\n")
-                    )
-                }
-                hir::HirExpression::Binary(bin) => {
-                    // BUG #237 DEBUG: Show binary expression details
-                    let left_desc = match &*bin.left {
-                        hir::HirExpression::Cast(c) => format!(
-                            "Cast(inner={:?}, target={:?})",
-                            std::mem::discriminant(&*c.expr),
-                            c.target_type
-                        ),
-                        hir::HirExpression::Signal(id) => format!("Signal({:?})", id),
-                        hir::HirExpression::Port(id) => format!("Port({:?})", id),
-                        other => format!("{:?}", std::mem::discriminant(other)),
-                    };
-                    let right_desc = match &*bin.right {
-                        hir::HirExpression::Cast(c) => format!(
-                            "Cast(inner={:?}, target={:?})",
-                            std::mem::discriminant(&*c.expr),
-                            c.target_type
-                        ),
-                        hir::HirExpression::Signal(id) => format!("Signal({:?})", id),
-                        hir::HirExpression::Port(id) => format!("Port({:?})", id),
-                        other => format!("{:?}", std::mem::discriminant(other)),
-                    };
-                    format!(
-                        "Binary(op={:?}, left={}, right={})",
-                        bin.op, left_desc, right_desc
-                    )
-                }
-                _ => format!(
-                    "expression of type {:?}",
-                    std::mem::discriminant(&assign.rhs)
-                ),
-            };
+            let rhs_desc = Self::describe_hir_expr(&assign.rhs);
 
             panic!(
                 "\n\n❌❌❌ COMPILATION ERROR: Assignment conversion failed! ❌❌❌\n\
@@ -4709,11 +4638,15 @@ impl<'hir> HirToMir<'hir> {
                  1. Function inlining failed due to excessive complexity or recursion depth\n\
                  2. Match expression with too many nested function calls\n\
                  3. Expression type not supported in continuous assignments\n\
+                 4. Field access on a sub-entity whose module is not imported\n\
                  \n\
                  For function calls, try:\n\
                  - Breaking the function into smaller pieces\n\
                  - Reducing match expression nesting depth\n\
                  - Using intermediate variables for complex sub-expressions\n\
+                 \n\
+                 If this involves a field access on a sub-entity (e.g., instance.port),\n\
+                 check that the entity is imported with a `use module::EntityName;` statement.\n\
                  \n\
                  This is Bug #85: Assignments must never be silently dropped!\n\
                  ❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌❌\n",
@@ -18076,6 +18009,70 @@ impl<'hir> HirToMir<'hir> {
         }
     }
 
+    /// Produce a human-readable description of an HIR expression for error messages.
+    fn describe_hir_expr(expr: &hir::HirExpression) -> String {
+        match expr {
+            hir::HirExpression::Signal(id) => format!("Signal({:?})", id),
+            hir::HirExpression::Port(id) => format!("Port({:?})", id),
+            hir::HirExpression::Variable(id) => format!("Variable({:?})", id),
+            hir::HirExpression::Literal(lit) => format!("Literal({:?})", lit),
+            hir::HirExpression::Binary(bin) => format!(
+                "Binary(op={:?}, left={}, right={})",
+                bin.op,
+                Self::describe_hir_expr(&bin.left),
+                Self::describe_hir_expr(&bin.right)
+            ),
+            hir::HirExpression::Unary(un) => format!(
+                "Unary(op={:?}, operand={})",
+                un.op,
+                Self::describe_hir_expr(&un.operand)
+            ),
+            hir::HirExpression::FieldAccess { base, field } => {
+                format!("FieldAccess({}.{})", Self::describe_hir_expr(base), field)
+            }
+            hir::HirExpression::Cast(cast) => format!(
+                "Cast(inner={}, target={:?})",
+                Self::describe_hir_expr(&cast.expr),
+                cast.target_type
+            ),
+            hir::HirExpression::Call(call) => {
+                format!("Call('{}', {} args)", call.function, call.args.len())
+            }
+            hir::HirExpression::Match(m) => format!(
+                "Match({} arms, scrutinee={})",
+                m.arms.len(),
+                Self::describe_hir_expr(&m.expr)
+            ),
+            hir::HirExpression::Index(base, idx) => format!(
+                "Index({}[{}])",
+                Self::describe_hir_expr(base),
+                Self::describe_hir_expr(idx)
+            ),
+            hir::HirExpression::Ternary { condition, .. } => {
+                format!("Ternary(cond={})", Self::describe_hir_expr(condition))
+            }
+            other => format!("{:?}", std::mem::discriminant(other)),
+        }
+    }
+
+    /// Produce a human-readable description of an HIR lvalue for error messages.
+    fn describe_hir_lvalue(lval: &hir::HirLValue) -> String {
+        match lval {
+            hir::HirLValue::Signal(id) => format!("signal_{}", id.0),
+            hir::HirLValue::Port(id) => format!("port_{}", id.0),
+            hir::HirLValue::Variable(id) => format!("variable_{}", id.0),
+            hir::HirLValue::Range(base, ..) => {
+                format!("{}[range]", Self::describe_hir_lvalue(base))
+            }
+            hir::HirLValue::FieldAccess { base, field } => {
+                format!("{}.{}", Self::describe_hir_lvalue(base), field)
+            }
+            hir::HirLValue::Index(base, ..) => {
+                format!("{}[index]", Self::describe_hir_lvalue(base))
+            }
+        }
+    }
+
     /// Convert struct/vector field access to bit slice
     fn convert_field_access(
         &mut self,
@@ -18205,6 +18202,7 @@ impl<'hir> HirToMir<'hir> {
                         "[FIELD_ACCESS] Checking if var {:?} is entity instance. entity_instance_outputs has {} entries",
                         var_id, self.entity_instance_outputs.len()
                     );
+
                     if let Some(output_ports) = self.entity_instance_outputs.get(var_id) {
                         // This variable is an entity instance - look up the output port
                         if let Some(&signal_id) = output_ports.get(&normalized_field_name) {

--- a/crates/skalp-sir/src/codegen/shared.rs
+++ b/crates/skalp-sir/src/codegen/shared.rs
@@ -131,7 +131,12 @@ impl<'a> SharedCodegen<'a> {
                     BinaryOperation::Sar | BinaryOperation::SDiv | BinaryOperation::SMod => {
                         left_width
                     }
-                    BinaryOperation::Shl | BinaryOperation::Shr => left_width,
+                    // Left shift can produce a result wider than the left operand.
+                    // E.g., `1-bit << 7` = 0x80 (8-bit). Use full 32-bit width
+                    // to avoid premature truncation; downstream nodes/registers
+                    // apply the correct final mask.
+                    BinaryOperation::Shl => 32,
+                    BinaryOperation::Shr => left_width,
                     BinaryOperation::Div | BinaryOperation::Mod => left_width,
                     BinaryOperation::Add | BinaryOperation::Sub => {
                         std::cmp::max(left_width, right_width)

--- a/crates/skalp-sir/src/mir_to_sir.rs
+++ b/crates/skalp-sir/src/mir_to_sir.rs
@@ -4545,7 +4545,12 @@ impl<'a> MirToSirConverter<'a> {
         // BUG FIX (GitHub #12): If the node already has a defined output (e.g., constant
         // driver nodes output to the actual signal name like `_s1`), return that output
         // instead of creating a phantom `node_{id}_out` signal that would never be written.
-        if let Some(node) = self.sir.combinational_nodes.iter().find(|n| n.id == node_id) {
+        if let Some(node) = self
+            .sir
+            .combinational_nodes
+            .iter()
+            .find(|n| n.id == node_id)
+        {
             if let Some(output) = node.outputs.first() {
                 return output.clone();
             }
@@ -4846,10 +4851,24 @@ impl<'a> MirToSirConverter<'a> {
                 // BUG FIX #117r: Allow flip-flops to overwrite continuous assignment drivers for state elements
                 // This happens when a signal has an initialization value (continuous assign) but is also
                 // assigned in sequential logic (needs flip-flop). The flip-flop should be the driver.
+                //
+                // BUG FIX: Also allow overwriting constant drivers (from initial values) with
+                // combinational drivers. This happens when a parent signal like `stage1_out = 0`
+                // gets a constant driver from convert_signals(), but is then driven by a child
+                // instance's output port (e.g., Register's `data_out = reg`). The instance
+                // output should take priority over the default constant.
+                let existing_is_constant = self.sir.combinational_nodes.iter().any(|n| {
+                    n.id == existing_driver && matches!(n.kind, SirNodeKind::Constant { .. })
+                });
+
                 if new_node_is_flipflop && signal.is_state {
                     // Remember to remove the signal from the old driver's outputs
                     old_driver_to_update = Some(existing_driver);
                     // Continue to set the flip-flop as driver
+                } else if existing_is_constant {
+                    // Constant drivers are default values that can be overwritten
+                    old_driver_to_update = Some(existing_driver);
+                    // Continue to set the new driver
                 } else {
                     // Don't overwrite - keep the first driver
                     return;
@@ -5554,7 +5573,6 @@ impl<'a> MirToSirConverter<'a> {
     fn flatten_instances(&mut self, instance_prefix: &str) {
         // Clone the instances list to avoid borrow checker issues
         let instances = self.mir.instances.clone();
-
         for instance in &instances {
             // Find the module being instantiated
             let child_module = self
@@ -6230,6 +6248,13 @@ impl<'a> MirToSirConverter<'a> {
                     span: None,
                 });
 
+                // Extract initial value from the flattened signal
+                let initial_u64 = flat_signal.initial.as_ref().and_then(|v| match v {
+                    Value::Integer(i) => Some(*i as u64),
+                    Value::BitVector { value, .. } => Some(*value),
+                    _ => None,
+                });
+
                 if is_register {
                     self.sir.state_elements.insert(
                         internal_name.clone(),
@@ -6243,6 +6268,38 @@ impl<'a> MirToSirConverter<'a> {
                             span: None,
                         },
                     );
+                } else if let Some(val) = initial_u64 {
+                    // BUG FIX: Non-register signals with initial values in child
+                    // modules need constant driver nodes, just like top-level signals
+                    // (see convert_signals GitHub #12 fix). Without this, constants
+                    // like `signal CYCLES_PER_BIT: nat[9] = 434` would be 0 at
+                    // runtime because no node drives them.
+                    let node_id = self.next_node_id();
+                    let output_ref = SignalRef {
+                        signal_id: internal_name.clone(),
+                        bit_range: None,
+                    };
+
+                    let node = SirNode {
+                        id: node_id,
+                        kind: SirNodeKind::Constant { value: val, width },
+                        inputs: vec![],
+                        outputs: vec![output_ref],
+                        clock_domain: None,
+                        impl_style_hint: ImplStyleHint::default(),
+                        span: None,
+                    };
+
+                    if let Some(sig) = self
+                        .sir
+                        .signals
+                        .iter_mut()
+                        .find(|s| s.name == internal_name)
+                    {
+                        sig.driver_node = Some(node_id);
+                    }
+
+                    self.sir.combinational_nodes.push(node);
                 }
             }
         }
@@ -6366,7 +6423,21 @@ impl<'a> MirToSirConverter<'a> {
                 let width = sir_type.width();
 
                 // Check if already registered (avoid duplicates)
-                if self.mir_to_internal_name.contains_key(&hierarchical_path) {
+                // BUG #85 FIX: Check both dot notation (ctr.count) and underscore notation
+                // (ctr_count) because the MIR converter names instance output port signals
+                // with underscores while hierarchical elaboration uses dots.
+                let underscore_path = format!("{}_{}", inst_prefix, port.name);
+                if self.mir_to_internal_name.contains_key(&hierarchical_path)
+                    || self.mir_to_internal_name.contains_key(&underscore_path)
+                {
+                    // Ensure the dot-notation path also maps to the same internal name
+                    // so that child logic resolving Port("count") → "ctr.count" finds the
+                    // same signal that the parent module's "ctr_count" references.
+                    if let Some(internal) = self.mir_to_internal_name.get(&underscore_path).cloned()
+                    {
+                        self.mir_to_internal_name
+                            .insert(hierarchical_path.clone(), internal);
+                    }
                     continue;
                 }
 
@@ -7434,7 +7505,13 @@ impl<'a> MirToSirConverter<'a> {
         parent_module_for_signals: Option<&Module>,
         parent_prefix: &str,
     ) -> usize {
-        // Process all statements to find assignments to target
+        // BUG FIX: Use "last write wins" semantics instead of returning on first match.
+        // In sequential blocks, an unconditional default (e.g., `valid_out = 0`) at the
+        // top of the block should NOT short-circuit conditional overrides deeper in the
+        // block (e.g., `if ... { valid_out = 1 }`). Process ALL statements and chain
+        // results together, matching the behavior of find_assignment_in_branch_for_instance.
+        let mut result: Option<usize> = None;
+
         for statement in statements {
             match statement {
                 Statement::Assignment(assign) => {
@@ -7508,11 +7585,12 @@ impl<'a> MirToSirConverter<'a> {
                                         );
 
                                         // Create MUX: cond ? value : current
-                                        return self.create_mux_node(
+                                        result = Some(self.create_mux_node(
                                             cond_node,
                                             value_node,
                                             current_node,
-                                        );
+                                        ));
+                                        continue;
                                     }
                                 }
                             }
@@ -7522,20 +7600,20 @@ impl<'a> MirToSirConverter<'a> {
                     };
 
                     if lhs == target {
-                        // Direct assignment to target - create node for RHS
-                        return self.create_expression_node_for_instance_with_context(
+                        // Save as current result (may be overridden by later conditionals)
+                        result = Some(self.create_expression_node_for_instance_with_context(
                             &assign.rhs,
                             inst_prefix,
                             port_mapping,
                             child_module,
                             parent_module_for_signals,
                             parent_prefix,
-                        );
+                        ));
                     }
                 }
                 Statement::If(if_stmt) => {
-                    // Build conditional MUX
-                    return self.synthesize_conditional_for_instance(
+                    // Build conditional MUX, passing current result as default
+                    let if_result = self.synthesize_conditional_for_instance_with_default(
                         if_stmt,
                         inst_prefix,
                         port_mapping,
@@ -7543,11 +7621,13 @@ impl<'a> MirToSirConverter<'a> {
                         target,
                         parent_module_for_signals,
                         parent_prefix,
+                        result,
                     );
+                    result = Some(if_result);
                 }
                 Statement::Case(case_stmt) => {
                     // BUG #237 FIX: Handle top-level Case statements too
-                    if let Some(val) = self.synthesize_case_for_target_for_instance(
+                    if let Some(val) = self.synthesize_case_for_target_for_instance_with_default(
                         case_stmt,
                         inst_prefix,
                         port_mapping,
@@ -7555,8 +7635,9 @@ impl<'a> MirToSirConverter<'a> {
                         target,
                         parent_module_for_signals,
                         parent_prefix,
+                        result,
                     ) {
-                        return val;
+                        result = Some(val);
                     }
                 }
                 Statement::ResolvedConditional(resolved) => {
@@ -7578,15 +7659,18 @@ impl<'a> MirToSirConverter<'a> {
                     };
                     if let Some(lhs_name) = lhs {
                         if lhs_name == target {
-                            return self.synthesize_conditional_for_instance(
-                                &resolved.original,
-                                inst_prefix,
-                                port_mapping,
-                                child_module,
-                                target,
-                                parent_module_for_signals,
-                                parent_prefix,
-                            );
+                            let resolved_result = self
+                                .synthesize_conditional_for_instance_with_default(
+                                    &resolved.original,
+                                    inst_prefix,
+                                    port_mapping,
+                                    child_module,
+                                    target,
+                                    parent_module_for_signals,
+                                    parent_prefix,
+                                    result,
+                                );
+                            result = Some(resolved_result);
                         }
                     }
                 }
@@ -7594,123 +7678,20 @@ impl<'a> MirToSirConverter<'a> {
             }
         }
 
-        // No assignment found - use signal ref (keep current value)
-        // BUG #117r FIX: Use instance-aware SignalRef for output port resolution
-        self.create_signal_ref_for_instance(
-            target,
-            inst_prefix,
-            port_mapping,
-            parent_module_for_signals,
-            parent_prefix,
-        )
-    }
-
-    /// Synthesize conditional assignment for instance (creates MUX nodes)
-    #[allow(clippy::too_many_arguments)]
-    fn synthesize_conditional_for_instance(
-        &mut self,
-        if_stmt: &IfStatement,
-        inst_prefix: &str,
-        port_mapping: &HashMap<String, Expression>,
-        child_module: &Module,
-        target: &str,
-        parent_module_for_signals: Option<&Module>,
-        parent_prefix: &str,
-    ) -> usize {
-        // Get values from then and else branches
-        let then_value = self.find_assignment_in_branch_for_instance(
-            &if_stmt.then_block.statements,
-            inst_prefix,
-            port_mapping,
-            child_module,
-            target,
-            parent_module_for_signals,
-            parent_prefix,
-        );
-
-        let else_value = if let Some(else_block) = &if_stmt.else_block {
-            self.find_assignment_in_branch_for_instance(
-                &else_block.statements,
+        // Return accumulated result, or keep current value if no assignment found
+        result.unwrap_or_else(|| {
+            // BUG #117r FIX: Use instance-aware SignalRef for output port resolution
+            self.create_signal_ref_for_instance(
+                target,
                 inst_prefix,
                 port_mapping,
-                child_module,
-                target,
                 parent_module_for_signals,
                 parent_prefix,
             )
-        } else {
-            None
-        };
-
-        // Build MUX based on what was found
-        match (then_value, else_value) {
-            (Some(then_val), Some(else_val)) => {
-                // Both branches assign: mux(cond, then, else)
-                let condition = self.create_expression_node_for_instance_with_context(
-                    &if_stmt.condition,
-                    inst_prefix,
-                    port_mapping,
-                    child_module,
-                    parent_module_for_signals,
-                    parent_prefix,
-                );
-                self.create_mux_node(condition, then_val, else_val)
-            }
-            (Some(then_val), None) => {
-                // Only then assigns: mux(cond, then, keep)
-                let condition = self.create_expression_node_for_instance_with_context(
-                    &if_stmt.condition,
-                    inst_prefix,
-                    port_mapping,
-                    child_module,
-                    parent_module_for_signals,
-                    parent_prefix,
-                );
-                // BUG #117r FIX: Use instance-aware SignalRef for output port resolution
-                let keep_val = self.create_signal_ref_for_instance(
-                    target,
-                    inst_prefix,
-                    port_mapping,
-                    parent_module_for_signals,
-                    parent_prefix,
-                );
-                self.create_mux_node(condition, then_val, keep_val)
-            }
-            (None, Some(else_val)) => {
-                // Only else assigns: mux(cond, keep, else)
-                let condition = self.create_expression_node_for_instance_with_context(
-                    &if_stmt.condition,
-                    inst_prefix,
-                    port_mapping,
-                    child_module,
-                    parent_module_for_signals,
-                    parent_prefix,
-                );
-                // BUG #117r FIX: Use instance-aware SignalRef for output port resolution
-                let keep_val = self.create_signal_ref_for_instance(
-                    target,
-                    inst_prefix,
-                    port_mapping,
-                    parent_module_for_signals,
-                    parent_prefix,
-                );
-                self.create_mux_node(condition, keep_val, else_val)
-            }
-            (None, None) => {
-                // Neither assigns: keep current value
-                // BUG #117r FIX: Use instance-aware SignalRef for output port resolution
-                self.create_signal_ref_for_instance(
-                    target,
-                    inst_prefix,
-                    port_mapping,
-                    parent_module_for_signals,
-                    parent_prefix,
-                )
-            }
-        }
+        })
     }
 
-    /// BUG #238 FIX: Synthesize conditional with explicit default value
+    /// Synthesize conditional with explicit default value
     /// This allows chaining multiple If statements where later ones wrap earlier results
     #[allow(clippy::too_many_arguments)]
     fn synthesize_conditional_for_instance_with_default(
@@ -7808,137 +7789,7 @@ impl<'a> MirToSirConverter<'a> {
         }
     }
 
-    /// Find assignment to target in a branch
-    /// BUG #238 FIX: Process ALL statements and chain them together.
-    /// In RTL, later assignments in a clocked block take priority over earlier ones.
-    /// So `if A { x = 1 } if B { x = 0 }` should give: mux(B, 0, mux(A, 1, current_x))
-    #[allow(clippy::too_many_arguments)]
-    fn find_assignment_in_branch_for_instance(
-        &mut self,
-        statements: &[Statement],
-        inst_prefix: &str,
-        port_mapping: &HashMap<String, Expression>,
-        child_module: &Module,
-        target: &str,
-        parent_module_for_signals: Option<&Module>,
-        parent_prefix: &str,
-    ) -> Option<usize> {
-        // BUG #238 FIX: Collect all statement results, then chain them together
-        // Later statements have higher priority (override earlier ones)
-        let mut result: Option<usize> = None;
-
-        for stmt in statements {
-            match stmt {
-                Statement::Assignment(assign) => {
-                    // BUG #34 FIX: After HIR→MIR expansion, each flattened element (mem_0_x, mem_1_x, etc.)
-                    // has its own assignment with a unique RHS expression (containing the correct index literal).
-                    // We must match the EXACT signal name, not the stripped base, otherwise all targets
-                    // will match the first assignment and use the wrong constant!
-
-                    let lhs_signal = match &assign.lhs {
-                        LValue::Signal(sig_id) => {
-                            // Signal assignment - use EXACT name, don't strip!
-                            // Each flattened element has its own assignment in MIR
-                            child_module
-                                .signals
-                                .iter()
-                                .find(|s| s.id == *sig_id)
-                                .map(|signal| format!("{}.{}", inst_prefix, signal.name))
-                        }
-                        LValue::BitSelect { base, .. } => {
-                            // Array index like mem[wr_ptr] - strip to match flattened targets
-                            // This case shouldn't happen after HIR→MIR expansion, but keep for safety
-                            let extracted = self.extract_base_signal_for_instance(
-                                base,
-                                inst_prefix,
-                                child_module,
-                            );
-                            extracted
-                                .as_ref()
-                                .map(|base_name| self.strip_flattened_index_suffix(base_name))
-                        }
-                        _ => None,
-                    };
-
-                    if let Some(lhs) = lhs_signal {
-                        // For Signal assignments: exact match (fifo.mem_0_x == fifo.mem_0_x)
-                        // For BitSelect assignments: compare stripped names
-                        let matches = if matches!(assign.lhs, LValue::Signal(_)) {
-                            lhs == target
-                        } else {
-                            let target_stripped = self.strip_flattened_index_suffix(target);
-                            lhs == target_stripped
-                        };
-                        if matches {
-                            // Found assignment for this target - this overrides any previous result
-                            result = Some(self.create_expression_node_for_instance_with_context(
-                                &assign.rhs,
-                                inst_prefix,
-                                port_mapping,
-                                child_module,
-                                parent_module_for_signals,
-                                parent_prefix,
-                            ));
-                        }
-                    }
-                }
-                Statement::If(nested_if) => {
-                    // BUG #238 FIX: Don't return immediately! Chain conditionals together.
-                    // Each If statement should wrap the previous result as the else case.
-                    let if_result = self.synthesize_conditional_for_instance_with_default(
-                        nested_if,
-                        inst_prefix,
-                        port_mapping,
-                        child_module,
-                        target,
-                        parent_module_for_signals,
-                        parent_prefix,
-                        result, // Pass current result as default (else case)
-                    );
-                    result = Some(if_result);
-                }
-                Statement::Block(block) => {
-                    // Recursively search within the block, passing current result as base
-                    if let Some(block_result) = self
-                        .find_assignment_in_branch_for_instance_with_default(
-                            &block.statements,
-                            inst_prefix,
-                            port_mapping,
-                            child_module,
-                            target,
-                            parent_module_for_signals,
-                            parent_prefix,
-                            result,
-                        )
-                    {
-                        result = Some(block_result);
-                    }
-                }
-                Statement::Case(case_stmt) => {
-                    // BUG #237 FIX: Handle Case/match statements in instance branches
-                    // This is critical for state machines that use match statements
-                    // BUG #244 FIX: Pass current result so unconditional assignments before
-                    // the case statement are used as the default when no case arm matches
-                    if let Some(val) = self.synthesize_case_for_target_for_instance_with_default(
-                        case_stmt,
-                        inst_prefix,
-                        port_mapping,
-                        child_module,
-                        target,
-                        parent_module_for_signals,
-                        parent_prefix,
-                        result, // BUG #244: Pass current result as default
-                    ) {
-                        result = Some(val);
-                    }
-                }
-                _ => {}
-            }
-        }
-        result
-    }
-
-    /// Helper for find_assignment_in_branch_for_instance that carries a default value
+    /// Find assignment to target in a branch, carrying a default value
     #[allow(clippy::too_many_arguments)]
     fn find_assignment_in_branch_for_instance_with_default(
         &mut self,
@@ -8046,152 +7897,7 @@ impl<'a> MirToSirConverter<'a> {
         result
     }
 
-    /// BUG #237 FIX: Synthesize case statement for a specific target in instance context
-    /// This is the instance-aware version of synthesize_case_for_target_with_default
-    #[allow(clippy::too_many_arguments)]
-    fn synthesize_case_for_target_for_instance(
-        &mut self,
-        case_stmt: &skalp_mir::CaseStatement,
-        inst_prefix: &str,
-        port_mapping: &HashMap<String, Expression>,
-        child_module: &Module,
-        target: &str,
-        parent_module_for_signals: Option<&Module>,
-        parent_prefix: &str,
-    ) -> Option<usize> {
-        // Create expression node for the case expression (e.g., state_reg)
-        let case_expr_node = self.create_expression_node_for_instance_with_context(
-            &case_stmt.expr,
-            inst_prefix,
-            port_mapping,
-            child_module,
-            parent_module_for_signals,
-            parent_prefix,
-        );
-
-        // Collect values and expressions for this target from all case arms
-        let mut case_arms: Vec<(Vec<&Expression>, Option<usize>)> = Vec::new();
-        let mut found_target = false;
-
-        for item in case_stmt.items.iter() {
-            // Recursively find assignment in this arm's block
-            let arm_value = self.find_assignment_in_branch_for_instance(
-                &item.block.statements,
-                inst_prefix,
-                port_mapping,
-                child_module,
-                target,
-                parent_module_for_signals,
-                parent_prefix,
-            );
-            if arm_value.is_some() {
-                found_target = true;
-            }
-            case_arms.push((item.values.iter().collect(), arm_value));
-        }
-
-        // Get default block value
-        let default_block_value = if let Some(default_block) = &case_stmt.default {
-            let val = self.find_assignment_in_branch_for_instance(
-                &default_block.statements,
-                inst_prefix,
-                port_mapping,
-                child_module,
-                target,
-                parent_module_for_signals,
-                parent_prefix,
-            );
-            if val.is_some() {
-                found_target = true;
-            }
-            val
-        } else {
-            None
-        };
-
-        // If no arm assigns to this target, return None
-        if !found_target {
-            return None;
-        }
-
-        // Use default block value, or signal ref (keep current value)
-        // BUG #117r FIX: Use instance-aware SignalRef for output port resolution
-        let mut current_mux = match default_block_value {
-            Some(block_val) => block_val, // Default block has assignment
-            None => self.create_signal_ref_for_instance(
-                target,
-                inst_prefix,
-                port_mapping,
-                parent_module_for_signals,
-                parent_prefix,
-            ), // Keep current value
-        };
-
-        // Build mux chain from last case to first (so first has priority)
-        for (values, arm_value) in case_arms.iter().rev() {
-            let value_node = match arm_value {
-                Some(val) => *val,
-                None => current_mux,
-            };
-
-            if values.is_empty() {
-                continue;
-            }
-
-            let condition_node = if values.len() == 1 {
-                let val_node = self.create_expression_node_for_instance_with_context(
-                    values[0],
-                    inst_prefix,
-                    port_mapping,
-                    child_module,
-                    parent_module_for_signals,
-                    parent_prefix,
-                );
-                self.create_binary_op_node(&skalp_mir::BinaryOp::Equal, case_expr_node, val_node)
-            } else {
-                let mut or_node = {
-                    let val_node = self.create_expression_node_for_instance_with_context(
-                        values[0],
-                        inst_prefix,
-                        port_mapping,
-                        child_module,
-                        parent_module_for_signals,
-                        parent_prefix,
-                    );
-                    self.create_binary_op_node(
-                        &skalp_mir::BinaryOp::Equal,
-                        case_expr_node,
-                        val_node,
-                    )
-                };
-                for value in &values[1..] {
-                    let val_node = self.create_expression_node_for_instance_with_context(
-                        value,
-                        inst_prefix,
-                        port_mapping,
-                        child_module,
-                        parent_module_for_signals,
-                        parent_prefix,
-                    );
-                    let eq_node = self.create_binary_op_node(
-                        &skalp_mir::BinaryOp::Equal,
-                        case_expr_node,
-                        val_node,
-                    );
-                    or_node =
-                        self.create_binary_op_node(&skalp_mir::BinaryOp::Or, or_node, eq_node);
-                }
-                or_node
-            };
-
-            let old_mux = current_mux;
-            current_mux = self.create_mux_node(condition_node, value_node, old_mux);
-        }
-
-        Some(current_mux)
-    }
-
-    /// BUG #244 FIX: Synthesize case statement with an explicit default value
+    /// Synthesize case statement with an explicit default value
     /// When an unconditional assignment precedes the case statement, pass it as default
     /// so that if no case arm matches, we use the unconditional value instead of "keep current"
     #[allow(clippy::too_many_arguments)]

--- a/crates/skalp-sir/tests/mir_to_sir_regression.rs
+++ b/crates/skalp-sir/tests/mir_to_sir_regression.rs
@@ -18,7 +18,7 @@
 use skalp_frontend::hir_builder::build_hir;
 use skalp_frontend::parse::parse;
 use skalp_mir::hir_to_mir::HirToMir;
-use skalp_sir::mir_to_sir::convert_mir_to_sir;
+use skalp_sir::mir_to_sir::{convert_mir_to_sir, convert_mir_to_sir_with_hierarchy};
 use skalp_sir::sir::*;
 
 // ============================================================================
@@ -854,4 +854,135 @@ impl SingleStage {
     let config = sir.pipeline_config.as_ref().unwrap();
     assert_eq!(config.stages, 1);
     // No pipeline registers should be inserted for single stage
+}
+
+// ============================================================================
+// Hierarchical Elaboration Tests
+// ============================================================================
+
+/// Compile multi-module SKALP source to SIR with hierarchical elaboration.
+/// Returns the SIR for the top module (last entity in the source).
+fn compile_hierarchy_to_sir(source: &str) -> SirModule {
+    let tree = parse(source);
+    let hir = build_hir(&tree).expect("HIR building should succeed");
+    let mut transformer = HirToMir::new();
+    let mir = transformer.transform(&hir);
+
+    assert!(
+        !mir.modules.is_empty(),
+        "MIR should have at least one module"
+    );
+    let top_module = mir.modules.last().expect("Should have a top module");
+    convert_mir_to_sir_with_hierarchy(&mir, top_module)
+}
+
+/// Regression test: unconditional default followed by conditional override in
+/// a child module's sequential block must produce a mux chain, not a constant.
+///
+/// Pattern (child module):
+///   on(clk.rise) {
+///     out_valid = 0            // unconditional default
+///     if rst { ... }
+///     else { if cond { out_valid = 1 } }  // conditional override
+///   }
+///
+/// Before the fix, `synthesize_sequential_logic_for_instance` returned on the
+/// first unconditional assignment (`out_valid = 0`), producing a constant-0
+/// node and dropping the entire conditional mux chain. This meant `out_valid`
+/// could never go high in hierarchical designs, even though it worked in
+/// standalone compilation.
+#[test]
+fn test_hierarchical_sequential_default_override() {
+    let source = r#"
+entity PulseGen {
+    in clk: clock
+    in rst: bit
+    in trigger: bit
+    out pulse: bit
+
+    signal count: nat[4] = 0
+    signal pulse_out: bit = 0
+}
+
+impl PulseGen {
+    on(clk.rise) {
+        pulse_out = 0
+        if rst {
+            count = 0
+            pulse_out = 0
+        } else {
+            if trigger {
+                count = count + 1
+            }
+            if count == 5 {
+                pulse_out = 1
+                count = 0
+            }
+        }
+    }
+
+    pulse = pulse_out
+}
+
+entity TopWrapper {
+    in clk: clock
+    in rst: bit
+    in trig: bit
+    out out_pulse: bit
+}
+
+impl TopWrapper {
+    use pulse_gen::PulseGen
+
+    let gen = PulseGen {
+        clk: clk,
+        rst: rst,
+        trigger: trig,
+        pulse: out_pulse,
+    }
+}
+"#;
+    let sir = compile_hierarchy_to_sir(source);
+
+    // pulse_out should be a state element in the elaborated design
+    assert!(
+        has_state_element(&sir, "gen.pulse_out"),
+        "gen.pulse_out should be a state element"
+    );
+
+    // Find the FlipFlop node that drives gen.pulse_out
+    let pulse_out_internal = resolve_name(&sir, "gen.pulse_out");
+    let ff_node = sir
+        .sequential_nodes
+        .iter()
+        .find(|n| n.outputs.iter().any(|o| o.signal_id == pulse_out_internal))
+        .expect("Should have a FlipFlop for gen.pulse_out");
+
+    // The FlipFlop's data input should come from a node (format: "node_N_out")
+    let data_input = &ff_node.inputs[1]; // inputs[0] is clock, inputs[1] is data
+    let data_node_name = &data_input.signal_id;
+
+    // Find the combinational node that drives the FlipFlop data input
+    let data_node_id: usize = data_node_name
+        .strip_prefix("node_")
+        .and_then(|s| s.strip_suffix("_out"))
+        .and_then(|s| s.parse().ok())
+        .expect("Data input should be a node reference (node_N_out)");
+
+    let data_node = sir
+        .combinational_nodes
+        .iter()
+        .find(|n| n.id == data_node_id)
+        .expect("Should find the data node driving pulse_out");
+
+    // CRITICAL CHECK: The data node must be a Mux (conditional logic), NOT a Constant.
+    // Before the fix, this was SirNodeKind::Constant { value: 0, .. } because
+    // the unconditional `pulse_out = 0` short-circuited the entire mux chain.
+    assert!(
+        matches!(data_node.kind, SirNodeKind::Mux),
+        "pulse_out's next-state should be driven by a Mux (conditional logic), \
+         not {:?}. The unconditional default 'pulse_out = 0' must not suppress \
+         the conditional override 'pulse_out = 1'.",
+        data_node.kind
+    );
 }


### PR DESCRIPTION
## Summary

Fixes five bugs in the hierarchical elaboration pipeline that caused incorrect simulation of multi-entity designs. Closes #14.

- **hir_builder**: Handle `FieldExpr` in `build_unary_expr` so `!tx_fifo.empty` compiles correctly
- **hir_to_mir**: Replace `std::mem::discriminant()` with readable expression type names in error messages
- **codegen/shared**: Return 32-bit width for left-shift (Shl) to fix `(1-bit << 7) & 0x1 = 0` truncation
- **mir_to_sir**: Create constant driver nodes for child module signals with initial values (e.g., `CYCLES_PER_BIT=434`)
- **mir_to_sir**: Use "last write wins" semantics in `synthesize_sequential_logic_for_instance` — an unconditional default (`valid_out = 0`) no longer suppresses conditional overrides (`if cond { valid_out = 1 }`)

Also removes dead code (superseded non-default synthesis functions) and adds a hierarchical regression test.

## Test plan

- [x] `cargo fmt --all` — clean
- [x] `cargo clippy --all-targets --all-features` — no new warnings
- [x] `skalp-frontend` lib tests — 111 passed
- [x] `skalp-mir` lib tests — 36 passed
- [x] `skalp-sir` lib tests — 9 passed
- [x] `skalp-sir` regression tests — 29 passed (including new `test_hierarchical_sequential_default_override`)
- [x] UART integration tests (CPU backend) — 11/12 passed (1 pre-existing FIFO multi-byte issue)
- [x] UART integration tests (GPU backend) — hierarchical RX verified passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)