### PR TITLE
Add HIR-based codegen for skalp, VHDL, and SystemVerilog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3036,6 +3036,7 @@ dependencies = [
  "skalp-codegen",
  "skalp-formal",
  "skalp-frontend",
+ "skalp-hir-codegen",
  "skalp-lint",
  "skalp-lir",
  "skalp-manifest",
@@ -3149,6 +3150,14 @@ dependencies = [
  "thiserror 1.0.69",
  "toml",
  "tracing",
+]
+
+[[package]]
+name = "skalp-hir-codegen"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "skalp-frontend",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ skalp-safety = { path = "crates/skalp-safety" }
 skalp-formal = { path = "crates/skalp-formal" }
 skalp-place-route = { path = "crates/skalp-place-route", features = ["programmer"] }
 skalp-vhdl = { path = "crates/skalp-vhdl" }
+skalp-hir-codegen = { path = "crates/skalp-hir-codegen" }
 
 # Library system
 skalp-resolve = { path = "crates/skalp-resolve" }
@@ -135,4 +136,5 @@ members = [
     "crates/skalp-incremental", "crates/skalp-asic", "crates/skalp-resolve", "crates/skalp-manifest", "crates/skalp-package",
     "crates/skalp-ml",
     "crates/skalp-vhdl",
+    "crates/skalp-hir-codegen",
 ]

--- a/crates/skalp-frontend/src/const_eval.rs
+++ b/crates/skalp-frontend/src/const_eval.rs
@@ -1504,6 +1504,7 @@ mod tests {
             name: "WIDTH".to_string(),
             const_type: HirType::Nat(0),
             value: HirExpression::Literal(HirLiteral::Integer(32)),
+            comments: vec![],
         };
 
         eval.register_constants(&[width_const]);
@@ -1525,6 +1526,7 @@ mod tests {
             name: "DEPTH".to_string(),
             const_type: HirType::Nat(0),
             value: HirExpression::Literal(HirLiteral::Integer(16)),
+            comments: vec![],
         };
 
         eval.register_constants(&[depth_const]);
@@ -1551,6 +1553,7 @@ mod tests {
             name: "WIDTH".to_string(),
             const_type: HirType::Nat(0),
             value: HirExpression::Literal(HirLiteral::Integer(32)),
+            comments: vec![],
         };
         eval.register_constants(&[width_const]);
 
@@ -1572,6 +1575,7 @@ mod tests {
             id: crate::hir::ConstantId(4),
             name: "BITS".to_string(),
             const_type: HirType::Nat(0),
+            comments: vec![],
             value: HirExpression::Binary(HirBinaryExpr {
                 op: HirBinaryOp::Mul,
                 left: Box::new(HirExpression::Literal(HirLiteral::Integer(8))),

--- a/crates/skalp-frontend/src/hir.rs
+++ b/crates/skalp-frontend/src/hir.rs
@@ -109,6 +109,9 @@ pub struct AssumedMechanismConfig {
 pub struct Hir {
     /// Module name
     pub name: String,
+    /// File-level header comments (license, module doc)
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Entities in this HIR
     pub entities: Vec<HirEntity>,
     /// Implementations
@@ -153,6 +156,9 @@ pub struct HirEntity {
     pub id: EntityId,
     /// Entity name
     pub name: String,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Whether this is an async (NCL) entity
     pub is_async: bool,
     /// Visibility
@@ -269,6 +275,9 @@ pub struct HirInstance {
     pub id: InstanceId,
     /// Instance name
     pub name: String,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Entity to instantiate
     pub entity: EntityId,
     /// Positional generic arguments (for monomorphization)
@@ -313,6 +322,9 @@ pub struct HirPort {
     pub id: PortId,
     /// Port name
     pub name: String,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Port direction
     pub direction: HirPortDirection,
     /// Port type
@@ -368,6 +380,9 @@ pub struct HirSignal {
     pub id: SignalId,
     /// Signal name
     pub name: String,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Signal type
     pub signal_type: HirType,
     /// Initial value
@@ -414,6 +429,9 @@ pub struct HirVariable {
     pub id: VariableId,
     /// Variable name
     pub name: String,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Variable type
     pub var_type: HirType,
     /// Initial value
@@ -430,6 +448,9 @@ pub struct HirConstant {
     pub id: ConstantId,
     /// Constant name
     pub name: String,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Constant type
     pub const_type: HirType,
     /// Constant value
@@ -454,6 +475,9 @@ pub struct HirFunction {
     pub is_const: bool,
     /// Function name
     pub name: String,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Generic parameters (Phase 1: type and const parameters)
     pub generics: Vec<HirGeneric>,
     /// Function parameters
@@ -474,6 +498,9 @@ pub struct HirFunction {
 pub struct HirEventBlock {
     /// Block identifier
     pub id: BlockId,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Event triggers
     pub triggers: Vec<HirEventTrigger>,
     /// Statements
@@ -520,6 +547,9 @@ pub enum HirResetPolarity {
 pub struct HirAssignment {
     /// Assignment identifier
     pub id: AssignmentId,
+    /// Documentation comments
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub comments: Vec<String>,
     /// Left-hand side
     pub lhs: HirLValue,
     /// Assignment type
@@ -2242,6 +2272,7 @@ impl HirBuilder {
         // Stub implementation - will be expanded in Week 4
         Hir {
             name: "main".to_string(),
+            comments: vec![],
             entities: Vec::new(),
             entity_aliases: Vec::new(),
             implementations: Vec::new(),
@@ -2336,6 +2367,7 @@ impl Hir {
     pub fn new(name: String) -> Self {
         Self {
             name,
+            comments: vec![],
             entities: Vec::new(),
             entity_aliases: Vec::new(),
             implementations: Vec::new(),

--- a/crates/skalp-frontend/src/hir_builder.rs
+++ b/crates/skalp-frontend/src/hir_builder.rs
@@ -8,7 +8,7 @@ use crate::safety_attributes::{
     AsilLevel, HsrAllocation, HsrDef, SafetyGoalDef, SafetyMechanismDef, VerificationMethod,
 };
 use crate::span::{LineIndex, SourceSpan};
-use crate::syntax::{SyntaxKind, SyntaxNode, SyntaxNodeExt};
+use crate::syntax::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxNodeExt};
 use crate::typeck::TypeChecker;
 use indexmap::IndexMap;
 use std::path::PathBuf;
@@ -365,6 +365,40 @@ impl HirBuilderContext {
             span = span.with_file(file.clone());
         }
         Some(span)
+    }
+
+    /// Collect leading comments from preceding siblings of a CST node.
+    /// Returns comment text with the `//` or `/* */` prefix stripped.
+    fn collect_leading_comments(node: &SyntaxNode) -> Vec<String> {
+        let mut comments = Vec::new();
+        let mut prev = node.prev_sibling_or_token();
+        // Walk backward, collecting comments and skipping whitespace
+        while let Some(ref element) = prev {
+            match element {
+                SyntaxElement::Token(tok) if tok.kind() == SyntaxKind::Whitespace => {
+                    prev = element.prev_sibling_or_token();
+                }
+                SyntaxElement::Token(tok) if tok.kind() == SyntaxKind::Comment => {
+                    let text = tok.text().to_string();
+                    // Strip comment prefix
+                    let stripped = if let Some(s) = text.strip_prefix("//") {
+                        s.trim().to_string()
+                    } else if let Some(s) =
+                        text.strip_prefix("/*").and_then(|s| s.strip_suffix("*/"))
+                    {
+                        s.trim().to_string()
+                    } else {
+                        text
+                    };
+                    comments.push(stripped);
+                    prev = element.prev_sibling_or_token();
+                }
+                _ => break,
+            }
+        }
+        // Reverse since we collected back-to-front
+        comments.reverse();
+        comments
     }
 
     // ========== Context Stack Methods (for unified assignment operator) ==========
@@ -907,6 +941,7 @@ impl HirBuilderContext {
                                                 base: Box::new(rhs_expr.clone()),
                                                 field: idx.to_string(),
                                             },
+                                            comments: vec![],
                                         };
                                         assignments.push(assignment);
                                     }
@@ -940,6 +975,7 @@ impl HirBuilderContext {
                                     power_config: None,
                                     safety_config: None,
                                     power_domain: self.current_default_power_domain.clone(),
+                                    comments: vec![],
                                 };
                                 signals.push(signal);
 
@@ -949,6 +985,7 @@ impl HirBuilderContext {
                                     lhs: HirLValue::Signal(SignalId(let_stmt.id.0)),
                                     assignment_type: HirAssignmentType::Combinational,
                                     rhs: let_stmt.value,
+                                    comments: vec![],
                                 };
                                 assignments.push(assignment);
                             }
@@ -1086,6 +1123,7 @@ impl HirBuilderContext {
             safety_mechanism_config,
             seooc_config,
             compiled_ip_config,
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -1137,6 +1175,7 @@ impl HirBuilderContext {
             power_domain_config,
             isolation_config: None, // TODO: Extract from #[isolation] attribute
             retention_config: None, // TODO: Extract from #[retention] attribute
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -1326,6 +1365,7 @@ impl HirBuilderContext {
                                     power_config: None,
                                     safety_config: None,
                                     power_domain: self.current_default_power_domain.clone(),
+                                    comments: vec![],
                                 };
                                 signals.push(implicit_signal);
                                 // Register in symbol table so both LHS and RHS references resolve
@@ -1368,6 +1408,7 @@ impl HirBuilderContext {
                                 var_type: let_stmt.var_type.clone(),
                                 initial_value: Some(let_stmt.value.clone()),
                                 span: self.make_span(&child),
+                                comments: vec![],
                             };
 
                             // Variables are registered in symbol table by build_let_statement()
@@ -1380,6 +1421,7 @@ impl HirBuilderContext {
                                 lhs: HirLValue::Variable(let_stmt.id),
                                 assignment_type: HirAssignmentType::Combinational,
                                 rhs: let_stmt.value,
+                                comments: vec![],
                             };
                             assignments.push(assignment);
                         }
@@ -1728,6 +1770,7 @@ impl HirBuilderContext {
                 connections,
                 safety_config: None,
                 variable_id: None,
+                comments: vec![],
             });
         }
     }
@@ -1784,6 +1827,7 @@ impl HirBuilderContext {
                                 power_config: None,
                                 safety_config: None,
                                 power_domain: None,
+                                comments: vec![],
                             });
 
                             // Add output connection
@@ -2120,6 +2164,7 @@ impl HirBuilderContext {
             connections,
             safety_config,
             variable_id: None,
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -2328,6 +2373,7 @@ impl HirBuilderContext {
             power_config,
             safety_config,
             power_domain: final_power_domain,
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -2563,6 +2609,7 @@ impl HirBuilderContext {
                     lhs: HirLValue::Variable(signal_var_id),
                     rhs: field_access,
                     assignment_type: HirAssignmentType::Blocking,
+                    comments: vec![],
                 };
                 stmts.push(HirStatement::Assignment(assignment));
             }
@@ -2609,6 +2656,7 @@ impl HirBuilderContext {
             var_type,
             initial_value,
             span: self.make_span(node),
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -2631,6 +2679,7 @@ impl HirBuilderContext {
             name,
             const_type,
             value,
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -2744,6 +2793,7 @@ impl HirBuilderContext {
             body,
             span: self.make_span(node),
             pipeline_config,
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -2782,6 +2832,7 @@ impl HirBuilderContext {
             id,
             triggers,
             statements,
+            comments: Self::collect_leading_comments(node),
         })
     }
 
@@ -3803,6 +3854,7 @@ impl HirBuilderContext {
             lhs,
             assignment_type,
             rhs,
+            comments: vec![],
         })
     }
 
@@ -4725,6 +4777,7 @@ impl HirBuilderContext {
                                 i,
                             )),
                             span: None,
+                            comments: vec![],
                         };
                         variables.push(variable);
                         let assignment = HirAssignment {
@@ -4737,6 +4790,7 @@ impl HirBuilderContext {
                                 iterator,
                                 i,
                             ),
+                            comments: vec![],
                         };
                         assignments.push(assignment);
                     }
@@ -5088,6 +5142,7 @@ impl HirBuilderContext {
                 lhs: Self::substitute_in_lvalue(&assign.lhs, var_id, var_name, value),
                 assignment_type: assign.assignment_type.clone(),
                 rhs: Self::substitute_in_expr(&assign.rhs, var_id, var_name, value),
+                comments: assign.comments.clone(),
             }),
             HirStatement::If(if_stmt) => HirStatement::If(HirIfStatement {
                 condition: Self::substitute_in_expr(&if_stmt.condition, var_id, var_name, value),

--- a/crates/skalp-frontend/src/lexer.rs
+++ b/crates/skalp-frontend/src/lexer.rs
@@ -550,10 +550,15 @@ pub enum Token {
     #[regex(r"'[bhd][a-zA-Z0-9_]*", |lex| lex.slice()[1..].to_owned())]
     Lifetime(String),
 
-    // Whitespace and comments (skipped but tracked for position)
+    // Comments (captured for comment preservation)
+    #[regex(r"//[^\n]*", |lex| lex.slice().to_string())]
+    LineComment(String),
+
+    #[regex(r"/\*[^*]*\*+([^/*][^*]*\*+)*/", |lex| lex.slice().to_string())]
+    BlockComment(String),
+
+    // Whitespace (skipped)
     #[regex(r"[ \t\n\f]+", logos::skip)]
-    #[regex(r"//[^\n]*", logos::skip)]
-    #[regex(r"/\*[^*]*\*+([^/*][^*]*\*+)*/", logos::skip)]
     // Error token for unknown/invalid input
     Error,
 }
@@ -573,6 +578,8 @@ impl fmt::Display for Token {
             Token::Lifetime(name) => write!(f, "'{}", name),
             Token::LeftParen => write!(f, "("),
             Token::RightParen => write!(f, ")"),
+            Token::LineComment(c) => write!(f, "{}", c),
+            Token::BlockComment(c) => write!(f, "{}", c),
             _ => write!(f, "{:?}", self),
         }
     }
@@ -938,9 +945,10 @@ entity Counter {
         let mut lexer = Lexer::new(source);
         let tokens: Vec<_> = lexer.tokenize().into_iter().map(|t| t.token).collect();
 
-        // Should skip the comment and only see: entity, Test
-        assert_eq!(tokens.len(), 2);
+        // Comments are now captured as tokens
+        assert_eq!(tokens.len(), 3);
         assert_eq!(tokens[0], Token::Entity);
-        assert_eq!(tokens[1], Token::Identifier("Test".to_string()));
+        assert_eq!(tokens[1], Token::BlockComment("/* comment */".to_string()));
+        assert_eq!(tokens[2], Token::Identifier("Test".to_string()));
     }
 }

--- a/crates/skalp-frontend/src/lib.rs
+++ b/crates/skalp-frontend/src/lib.rs
@@ -2375,6 +2375,7 @@ pub fn build_hir(_ast: &ast::SourceFile) -> Result<Hir> {
     // Return empty HIR - actual work happens in parse_and_build_hir
     Ok(Hir {
         name: "design".to_string(),
+        comments: vec![],
         entities: Vec::new(),
         entity_aliases: Vec::new(),
         implementations: Vec::new(),

--- a/crates/skalp-frontend/src/monomorphization/engine.rs
+++ b/crates/skalp-frontend/src/monomorphization/engine.rs
@@ -101,6 +101,7 @@ impl<'hir> MonomorphizationEngine<'hir> {
 
             let current_hir = Hir {
                 name: hir.name.clone(),
+                comments: hir.comments.clone(),
                 entities: current_entities.clone(),
                 entity_aliases: hir.entity_aliases.clone(),
                 implementations: current_implementations.clone(),
@@ -419,6 +420,7 @@ impl<'hir> MonomorphizationEngine<'hir> {
 
         Hir {
             name: hir.name.clone(),
+            comments: hir.comments.clone(),
             entities: new_entities,
             entity_aliases: hir.entity_aliases.clone(),
             implementations: new_implementations,
@@ -468,6 +470,7 @@ impl<'hir> MonomorphizationEngine<'hir> {
                 crate::hir::HirPort {
                     id: new_id,
                     name: port.name.clone(),
+                    comments: port.comments.clone(),
                     direction: port.direction.clone(),
                     port_type: self.substitute_type(&port.port_type, instantiation),
                     physical_constraints: port.physical_constraints.clone(),
@@ -508,6 +511,7 @@ impl<'hir> MonomorphizationEngine<'hir> {
         let specialized_entity = HirEntity {
             id: specialized_id,
             name: instantiation.mangled_name(),
+            comments: entity.comments.clone(),
             is_async: entity.is_async, // Preserve async status for NCL entities
             visibility: entity.visibility,
             ports: specialized_ports,
@@ -581,6 +585,7 @@ impl<'hir> MonomorphizationEngine<'hir> {
                         let new_const = HirConstant {
                             id: constant.id,
                             name: constant.name.clone(),
+                            comments: constant.comments.clone(),
                             const_type: constant.const_type.clone(),
                             value: specialized_expr,
                         };

--- a/crates/skalp-frontend/src/parse.rs
+++ b/crates/skalp-frontend/src/parse.rs
@@ -5667,11 +5667,25 @@ impl<'a> ParseState<'a> {
         self.current >= self.tokens.len()
     }
 
-    /// Peek at a token without consuming it
+    /// Peek at a token without consuming it, skipping trivia tokens.
+    /// offset=1 returns the next non-trivia token after current.
     fn peek_kind(&self, offset: usize) -> Option<SyntaxKind> {
-        let index = self.current + offset;
-        if index < self.tokens.len() {
-            Some(SyntaxKind::from(self.tokens[index].token.clone()))
+        let mut pos = self.current;
+        let mut skipped = 0;
+
+        while skipped < offset {
+            pos += 1;
+            if pos >= self.tokens.len() {
+                return None;
+            }
+            let kind = SyntaxKind::from(self.tokens[pos].token.clone());
+            if !kind.is_trivia() {
+                skipped += 1;
+            }
+        }
+
+        if pos < self.tokens.len() {
+            Some(SyntaxKind::from(self.tokens[pos].token.clone()))
         } else {
             None
         }
@@ -5809,14 +5823,21 @@ impl<'a> ParseState<'a> {
         self.current_kind().filter(|k| k.is_operator())
     }
 
-    /// Consume current token
-    fn bump(&mut self) {
+    /// Internal: consume current token without skipping trivia afterward.
+    /// Used by `skip_trivia()` to avoid infinite recursion.
+    fn bump_raw(&mut self) {
         if let Some(token) = self.current_token() {
             let kind = SyntaxKind::from(token.token.clone());
             let text = &self.source[token.span.clone()];
             self.builder.token(rowan::SyntaxKind(kind as u16), text);
             self.current += 1;
         }
+    }
+
+    /// Consume current token and skip any following trivia (comments, whitespace).
+    fn bump(&mut self) {
+        self.bump_raw();
+        self.eat_trivia();
     }
 
     /// Consume current token as an identifier, even if it's a keyword
@@ -5829,6 +5850,7 @@ impl<'a> ParseState<'a> {
                 .token(rowan::SyntaxKind(SyntaxKind::Ident as u16), text);
             self.current += 1;
         }
+        self.eat_trivia();
     }
 
     /// Check if current token can be used as an identifier
@@ -5858,15 +5880,21 @@ impl<'a> ParseState<'a> {
         }
     }
 
-    /// Skip whitespace and comments
-    fn skip_trivia(&mut self) {
+    /// Internal: consume trivia tokens (comments, whitespace) at current position.
+    /// Does NOT use `bump()` to avoid double-skipping.
+    fn eat_trivia(&mut self) {
         while let Some(kind) = self.current_kind() {
             if kind.is_trivia() {
-                self.bump();
+                self.bump_raw();
             } else {
                 break;
             }
         }
+    }
+
+    /// Skip whitespace and comments (public entry point, same as eat_trivia)
+    fn skip_trivia(&mut self) {
+        self.eat_trivia();
     }
 
     /// Check if we're at a closing angle bracket, treating >> as two >

--- a/crates/skalp-frontend/src/syntax.rs
+++ b/crates/skalp-frontend/src/syntax.rs
@@ -1159,6 +1159,9 @@ impl From<crate::lexer::Token> for SyntaxKind {
             Token::None => NoneKw,
             Token::Keeper => KeeperKw,
 
+            Token::LineComment(_) => Comment,
+            Token::BlockComment(_) => Comment,
+
             Token::Error => Error,
         }
     }

--- a/crates/skalp-hir-codegen/Cargo.toml
+++ b/crates/skalp-hir-codegen/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "skalp-hir-codegen"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+skalp-frontend = { path = "../skalp-frontend" }
+anyhow = "1.0"

--- a/crates/skalp-hir-codegen/src/lib.rs
+++ b/crates/skalp-hir-codegen/src/lib.rs
@@ -1,0 +1,156 @@
+//! HIR-based code generation for skalp, VHDL, and SystemVerilog
+//!
+//! Generates source code directly from the HIR (High-level IR), enabling
+//! transpilation between hardware description languages without going
+//! through MIR lowering.
+
+mod skalp_emit;
+mod sv_emit;
+mod vhdl_emit;
+
+use anyhow::Result;
+use skalp_frontend::hir::*;
+use std::collections::HashMap;
+use std::fmt::Write;
+
+/// Generate skalp source code from HIR
+pub fn generate_skalp_source(hir: &Hir) -> Result<String> {
+    let resolver = NameResolver::from_hir(hir);
+    skalp_emit::emit_file(hir, &resolver)
+}
+
+/// Generate VHDL source code from HIR
+pub fn generate_vhdl(hir: &Hir) -> Result<String> {
+    let resolver = NameResolver::from_hir(hir);
+    vhdl_emit::emit_file(hir, &resolver)
+}
+
+/// Generate SystemVerilog source code from HIR
+pub fn generate_systemverilog(hir: &Hir) -> Result<String> {
+    let resolver = NameResolver::from_hir(hir);
+    sv_emit::emit_file(hir, &resolver)
+}
+
+/// Maps numeric IDs back to names and types for readable emission
+pub(crate) struct NameResolver {
+    pub ports: HashMap<PortId, (String, HirType)>,
+    pub signals: HashMap<SignalId, (String, HirType)>,
+    pub variables: HashMap<VariableId, (String, HirType)>,
+    pub constants: HashMap<ConstantId, (String, HirType)>,
+    pub entities: HashMap<EntityId, String>,
+    pub functions: HashMap<FunctionId, String>,
+}
+
+impl NameResolver {
+    pub fn from_hir(hir: &Hir) -> Self {
+        let mut resolver = Self {
+            ports: HashMap::new(),
+            signals: HashMap::new(),
+            variables: HashMap::new(),
+            constants: HashMap::new(),
+            entities: HashMap::new(),
+            functions: HashMap::new(),
+        };
+
+        for entity in &hir.entities {
+            resolver.entities.insert(entity.id, entity.name.clone());
+            for port in &entity.ports {
+                resolver
+                    .ports
+                    .insert(port.id, (port.name.clone(), port.port_type.clone()));
+            }
+            for signal in &entity.signals {
+                resolver
+                    .signals
+                    .insert(signal.id, (signal.name.clone(), signal.signal_type.clone()));
+            }
+        }
+
+        for imp in &hir.implementations {
+            for signal in &imp.signals {
+                resolver
+                    .signals
+                    .insert(signal.id, (signal.name.clone(), signal.signal_type.clone()));
+            }
+            for variable in &imp.variables {
+                resolver.variables.insert(
+                    variable.id,
+                    (variable.name.clone(), variable.var_type.clone()),
+                );
+            }
+            for constant in &imp.constants {
+                resolver.constants.insert(
+                    constant.id,
+                    (constant.name.clone(), constant.const_type.clone()),
+                );
+            }
+            for func in &imp.functions {
+                resolver.functions.insert(func.id, func.name.clone());
+            }
+        }
+
+        for func in &hir.functions {
+            resolver.functions.insert(func.id, func.name.clone());
+        }
+
+        resolver
+    }
+
+    pub fn port_name(&self, id: PortId) -> &str {
+        self.ports
+            .get(&id)
+            .map(|(n, _)| n.as_str())
+            .unwrap_or("unknown_port")
+    }
+
+    pub fn signal_name(&self, id: SignalId) -> &str {
+        self.signals
+            .get(&id)
+            .map(|(n, _)| n.as_str())
+            .unwrap_or("unknown_signal")
+    }
+
+    pub fn variable_name(&self, id: VariableId) -> &str {
+        self.variables
+            .get(&id)
+            .map(|(n, _)| n.as_str())
+            .unwrap_or("unknown_var")
+    }
+
+    pub fn constant_name(&self, id: ConstantId) -> &str {
+        self.constants
+            .get(&id)
+            .map(|(n, _)| n.as_str())
+            .unwrap_or("unknown_const")
+    }
+
+    pub fn entity_name(&self, id: EntityId) -> &str {
+        self.entities
+            .get(&id)
+            .map(|n| n.as_str())
+            .unwrap_or("unknown_entity")
+    }
+
+    pub(crate) fn from_empty() -> Self {
+        Self {
+            ports: HashMap::new(),
+            signals: HashMap::new(),
+            variables: HashMap::new(),
+            constants: HashMap::new(),
+            entities: HashMap::new(),
+            functions: HashMap::new(),
+        }
+    }
+}
+
+/// Emit comments with the given prefix and indentation
+pub(crate) fn emit_comments(out: &mut String, comments: &[String], prefix: &str, indent: &str) {
+    for comment in comments {
+        let _ = writeln!(out, "{indent}{prefix} {comment}");
+    }
+}
+
+/// Generate indentation string
+pub(crate) fn indent(level: usize) -> String {
+    "    ".repeat(level)
+}

--- a/crates/skalp-hir-codegen/src/skalp_emit.rs
+++ b/crates/skalp-hir-codegen/src/skalp_emit.rs
@@ -1,0 +1,768 @@
+//! HIR → skalp source code emitter
+
+use crate::{emit_comments, indent, NameResolver};
+use anyhow::Result;
+use skalp_frontend::hir::*;
+use std::fmt::Write;
+
+pub(crate) fn emit_file(hir: &Hir, resolver: &NameResolver) -> Result<String> {
+    let mut out = String::new();
+
+    emit_comments(&mut out, &hir.comments, "//", "");
+
+    for entity in &hir.entities {
+        emit_entity(&mut out, entity, resolver);
+        writeln!(out)?;
+    }
+
+    for (i, imp) in hir.implementations.iter().enumerate() {
+        emit_impl(&mut out, imp, resolver);
+        if i + 1 < hir.implementations.len() {
+            writeln!(out)?;
+        }
+    }
+
+    Ok(out)
+}
+
+fn emit_entity(out: &mut String, entity: &HirEntity, resolver: &NameResolver) {
+    emit_comments(out, &entity.comments, "//", "");
+
+    if entity.is_async {
+        out.push_str("async ");
+    }
+    write!(out, "entity {}", entity.name).unwrap();
+
+    // Generics
+    if !entity.generics.is_empty() {
+        out.push('<');
+        for (i, generic) in entity.generics.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            emit_generic(out, generic);
+        }
+        out.push('>');
+    }
+
+    out.push_str(" {\n");
+
+    // Ports
+    for port in &entity.ports {
+        emit_comments(out, &port.comments, "//", &indent(1));
+        let ind = indent(1);
+        let dir = match port.direction {
+            HirPortDirection::Input => "in",
+            HirPortDirection::Output => "out",
+            HirPortDirection::Bidirectional => "inout",
+            HirPortDirection::Protocol => "port",
+        };
+        let ty = emit_type(&port.port_type, resolver);
+        writeln!(out, "{ind}{dir} {}: {ty}", port.name).unwrap();
+    }
+
+    out.push_str("}\n");
+}
+
+fn emit_generic(out: &mut String, generic: &HirGeneric) {
+    match &generic.param_type {
+        HirGenericType::Width => {
+            write!(out, "{}", generic.name).unwrap();
+        }
+        HirGenericType::Const(ty) => {
+            write!(out, "{}: {}", generic.name, emit_type_inline(ty)).unwrap();
+        }
+        HirGenericType::Type => {
+            write!(out, "{}: type", generic.name).unwrap();
+        }
+        HirGenericType::TypeWithBounds(bounds) => {
+            write!(out, "{}: {}", generic.name, bounds.join(" + ")).unwrap();
+        }
+        HirGenericType::ClockDomain => {
+            write!(out, "'{}", generic.name).unwrap();
+        }
+        HirGenericType::PowerDomain { .. } => {
+            write!(out, "'{}", generic.name).unwrap();
+        }
+        HirGenericType::Intent => {
+            write!(out, "{}: intent", generic.name).unwrap();
+        }
+    }
+    if let Some(ref default) = generic.default_value {
+        write!(
+            out,
+            " = {}",
+            emit_expression_inline(default, &NameResolver::from_empty())
+        )
+        .unwrap();
+    }
+}
+
+fn emit_impl(out: &mut String, imp: &HirImplementation, resolver: &NameResolver) {
+    let entity_name = resolver.entity_name(imp.entity);
+    writeln!(out, "impl {entity_name} {{").unwrap();
+
+    // Signals
+    for signal in &imp.signals {
+        emit_signal(out, signal, resolver, 1);
+    }
+
+    // Variables
+    for variable in &imp.variables {
+        emit_variable(out, variable, resolver, 1);
+    }
+
+    // Constants
+    for constant in &imp.constants {
+        emit_constant(out, constant, resolver, 1);
+    }
+
+    // Functions
+    for func in &imp.functions {
+        emit_function(out, func, resolver, 1);
+    }
+
+    // Assignments (combinational)
+    for assign in &imp.assignments {
+        emit_assignment(out, assign, resolver, 1);
+    }
+
+    // Instances
+    for inst in &imp.instances {
+        emit_instance(out, inst, resolver, 1);
+    }
+
+    // Event blocks
+    for eb in &imp.event_blocks {
+        emit_event_block(out, eb, resolver, 1);
+    }
+
+    out.push_str("}\n");
+}
+
+fn emit_signal(out: &mut String, signal: &HirSignal, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &signal.comments, "//", &ind);
+    let ty = emit_type(&signal.signal_type, resolver);
+    write!(out, "{ind}signal {}: {ty}", signal.name).unwrap();
+    if let Some(ref init) = signal.initial_value {
+        write!(out, " = {}", emit_expression_inline(init, resolver)).unwrap();
+    }
+    writeln!(out).unwrap();
+}
+
+fn emit_variable(out: &mut String, variable: &HirVariable, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &variable.comments, "//", &ind);
+    let ty = emit_type(&variable.var_type, resolver);
+    write!(out, "{ind}var {}: {ty}", variable.name).unwrap();
+    if let Some(ref init) = variable.initial_value {
+        write!(out, " = {}", emit_expression_inline(init, resolver)).unwrap();
+    }
+    writeln!(out).unwrap();
+}
+
+fn emit_constant(out: &mut String, constant: &HirConstant, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &constant.comments, "//", &ind);
+    let ty = emit_type(&constant.const_type, resolver);
+    writeln!(
+        out,
+        "{ind}const {}: {ty} = {}",
+        constant.name,
+        emit_expression_inline(&constant.value, resolver)
+    )
+    .unwrap();
+}
+
+fn emit_function(out: &mut String, func: &HirFunction, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &func.comments, "//", &ind);
+    if func.is_const {
+        write!(out, "{ind}const ").unwrap();
+    } else {
+        write!(out, "{ind}").unwrap();
+    }
+    write!(out, "fn {}", func.name).unwrap();
+
+    // Generics
+    if !func.generics.is_empty() {
+        out.push('<');
+        for (i, generic) in func.generics.iter().enumerate() {
+            if i > 0 {
+                out.push_str(", ");
+            }
+            emit_generic(out, generic);
+        }
+        out.push('>');
+    }
+
+    // Parameters
+    out.push('(');
+    for (i, param) in func.params.iter().enumerate() {
+        if i > 0 {
+            out.push_str(", ");
+        }
+        let ty = emit_type(&param.param_type, resolver);
+        write!(out, "{}: {ty}", param.name).unwrap();
+    }
+    out.push(')');
+
+    // Return type
+    if let Some(ref ret_ty) = func.return_type {
+        write!(out, " -> {}", emit_type(ret_ty, resolver)).unwrap();
+    }
+
+    writeln!(out, " {{").unwrap();
+    for stmt in &func.body {
+        emit_statement(out, stmt, resolver, level + 1);
+    }
+    writeln!(out, "{ind}}}").unwrap();
+}
+
+fn emit_assignment(
+    out: &mut String,
+    assign: &HirAssignment,
+    resolver: &NameResolver,
+    level: usize,
+) {
+    let ind = indent(level);
+    emit_comments(out, &assign.comments, "//", &ind);
+    let lhs = emit_lvalue(&assign.lhs, resolver);
+    let rhs = emit_expression_inline(&assign.rhs, resolver);
+    writeln!(out, "{ind}{lhs} = {rhs}").unwrap();
+}
+
+fn emit_instance(out: &mut String, inst: &HirInstance, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &inst.comments, "//", &ind);
+    let entity_name = resolver.entity_name(inst.entity);
+    write!(out, "{ind}let {} = {entity_name}", inst.name).unwrap();
+
+    // Generic arguments
+    if !inst.generic_args.is_empty() || !inst.named_generic_args.is_empty() {
+        out.push('<');
+        let mut first = true;
+        for arg in &inst.generic_args {
+            if !first {
+                out.push_str(", ");
+            }
+            write!(out, "{}", emit_expression_inline(arg, resolver)).unwrap();
+            first = false;
+        }
+        for (name, arg) in &inst.named_generic_args {
+            if !first {
+                out.push_str(", ");
+            }
+            write!(out, "{name}: {}", emit_expression_inline(arg, resolver)).unwrap();
+            first = false;
+        }
+        out.push('>');
+    }
+
+    // Port connections
+    out.push_str(" {\n");
+    for conn in &inst.connections {
+        let ind2 = indent(level + 1);
+        writeln!(
+            out,
+            "{ind2}{}: {}",
+            conn.port,
+            emit_expression_inline(&conn.expr, resolver)
+        )
+        .unwrap();
+    }
+    writeln!(out, "{ind}}}").unwrap();
+}
+
+fn emit_event_block(out: &mut String, eb: &HirEventBlock, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &eb.comments, "//", &ind);
+    write!(out, "{ind}on(").unwrap();
+    for (i, trigger) in eb.triggers.iter().enumerate() {
+        if i > 0 {
+            out.push_str(" | ");
+        }
+        let sig = match &trigger.signal {
+            HirEventSignal::Port(id) => resolver.port_name(*id).to_string(),
+            HirEventSignal::Signal(id) => resolver.signal_name(*id).to_string(),
+        };
+        let edge = match trigger.edge {
+            HirEdgeType::Rising => "rise",
+            HirEdgeType::Falling => "fall",
+            HirEdgeType::Both => "rise", // approximate
+            HirEdgeType::Active => "active",
+            HirEdgeType::Inactive => "inactive",
+        };
+        write!(out, "{sig}.{edge}").unwrap();
+    }
+    writeln!(out, ") {{").unwrap();
+    for stmt in &eb.statements {
+        emit_statement(out, stmt, resolver, level + 1);
+    }
+    writeln!(out, "{ind}}}").unwrap();
+}
+
+fn emit_statement(out: &mut String, stmt: &HirStatement, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    match stmt {
+        HirStatement::Assignment(assign) => {
+            emit_assignment(out, assign, resolver, level);
+        }
+        HirStatement::If(if_stmt) => {
+            let cond = emit_expression_inline(&if_stmt.condition, resolver);
+            writeln!(out, "{ind}if ({cond}) {{").unwrap();
+            for s in &if_stmt.then_statements {
+                emit_statement(out, s, resolver, level + 1);
+            }
+            if let Some(ref else_stmts) = if_stmt.else_statements {
+                writeln!(out, "{ind}}} else {{").unwrap();
+                for s in else_stmts {
+                    emit_statement(out, s, resolver, level + 1);
+                }
+            }
+            writeln!(out, "{ind}}}").unwrap();
+        }
+        HirStatement::Match(match_stmt) => {
+            let expr = emit_expression_inline(&match_stmt.expr, resolver);
+            writeln!(out, "{ind}match {expr} {{").unwrap();
+            for arm in &match_stmt.arms {
+                let pat = emit_pattern(&arm.pattern);
+                write!(out, "    {pat}").unwrap();
+                if let Some(ref guard) = arm.guard {
+                    write!(out, " if {}", emit_expression_inline(guard, resolver)).unwrap();
+                }
+                writeln!(out, " => {{").unwrap();
+                for s in &arm.statements {
+                    emit_statement(out, s, resolver, level + 2);
+                }
+                writeln!(out, "{}    }}", indent(level)).unwrap();
+            }
+            writeln!(out, "{ind}}}").unwrap();
+        }
+        HirStatement::Let(let_stmt) => {
+            let ty = emit_type(&let_stmt.var_type, resolver);
+            let val = emit_expression_inline(&let_stmt.value, resolver);
+            let mutk = if let_stmt.mutable { "mut " } else { "" };
+            writeln!(out, "{ind}let {mutk}{}: {ty} = {val}", let_stmt.name).unwrap();
+        }
+        HirStatement::Return(expr) => {
+            if let Some(ref e) = expr {
+                writeln!(out, "{ind}return {}", emit_expression_inline(e, resolver)).unwrap();
+            } else {
+                writeln!(out, "{ind}return").unwrap();
+            }
+        }
+        HirStatement::Expression(expr) => {
+            writeln!(out, "{ind}{}", emit_expression_inline(expr, resolver)).unwrap();
+        }
+        HirStatement::For(for_stmt) => {
+            let start = emit_expression_inline(&for_stmt.range.start, resolver);
+            let end = emit_expression_inline(&for_stmt.range.end, resolver);
+            let range_op = if for_stmt.range.inclusive {
+                "..="
+            } else {
+                ".."
+            };
+            writeln!(
+                out,
+                "{ind}for {} in {start}{range_op}{end} {{",
+                for_stmt.iterator
+            )
+            .unwrap();
+            for s in &for_stmt.body {
+                emit_statement(out, s, resolver, level + 1);
+            }
+            writeln!(out, "{ind}}}").unwrap();
+        }
+        HirStatement::Block(stmts) => {
+            writeln!(out, "{ind}{{").unwrap();
+            for s in stmts {
+                emit_statement(out, s, resolver, level + 1);
+            }
+            writeln!(out, "{ind}}}").unwrap();
+        }
+        HirStatement::GenerateFor(gen) => {
+            let start = emit_expression_inline(&gen.range.start, resolver);
+            let end = emit_expression_inline(&gen.range.end, resolver);
+            let range_op = if gen.range.inclusive { "..=" } else { ".." };
+            writeln!(
+                out,
+                "{ind}generate for {} in {start}{range_op}{end} {{",
+                gen.iterator
+            )
+            .unwrap();
+            emit_generate_body(out, &gen.body, resolver, level + 1);
+            writeln!(out, "{ind}}}").unwrap();
+        }
+        HirStatement::GenerateIf(gen) => {
+            let cond = emit_expression_inline(&gen.condition, resolver);
+            writeln!(out, "{ind}generate if ({cond}) {{").unwrap();
+            emit_generate_body(out, &gen.then_body, resolver, level + 1);
+            if let Some(ref else_body) = gen.else_body {
+                writeln!(out, "{ind}}} else {{").unwrap();
+                emit_generate_body(out, else_body, resolver, level + 1);
+            }
+            writeln!(out, "{ind}}}").unwrap();
+        }
+        HirStatement::Barrier(barrier) => {
+            writeln!(out, "{ind}barrier // stage {}", barrier.stage_id).unwrap();
+        }
+        _ => {
+            writeln!(out, "{ind}// unsupported statement").unwrap();
+        }
+    }
+}
+
+fn emit_generate_body(
+    out: &mut String,
+    body: &HirGenerateBody,
+    resolver: &NameResolver,
+    level: usize,
+) {
+    for signal in &body.signals {
+        emit_signal(out, signal, resolver, level);
+    }
+    for inst in &body.instances {
+        emit_instance(out, inst, resolver, level);
+    }
+    for eb in &body.event_blocks {
+        emit_event_block(out, eb, resolver, level);
+    }
+    for assign in &body.assignments {
+        emit_assignment(out, assign, resolver, level);
+    }
+    for stmt in &body.generate_stmts {
+        emit_statement(out, stmt, resolver, level);
+    }
+}
+
+fn emit_pattern(pat: &HirPattern) -> String {
+    match pat {
+        HirPattern::Literal(lit) => emit_literal(lit),
+        HirPattern::Variable(name) => name.clone(),
+        HirPattern::Wildcard => "_".to_string(),
+        HirPattern::Tuple(pats) => {
+            let inner: Vec<_> = pats.iter().map(emit_pattern).collect();
+            format!("({})", inner.join(", "))
+        }
+        HirPattern::Path(enum_name, variant) => format!("{enum_name}::{variant}"),
+    }
+}
+
+fn emit_literal(lit: &HirLiteral) -> String {
+    match lit {
+        HirLiteral::Integer(n) => n.to_string(),
+        HirLiteral::Boolean(b) => b.to_string(),
+        HirLiteral::Float(f) => format!("{f}"),
+        HirLiteral::String(s) => format!("\"{s}\""),
+        HirLiteral::BitVector(bits) => {
+            let mut s = String::from("0b");
+            for b in bits {
+                s.push(if *b { '1' } else { '0' });
+            }
+            s
+        }
+    }
+}
+
+pub(crate) fn emit_expression_inline(expr: &HirExpression, resolver: &NameResolver) -> String {
+    match expr {
+        HirExpression::Literal(lit) => emit_literal(lit),
+        HirExpression::Signal(id) => resolver.signal_name(*id).to_string(),
+        HirExpression::Port(id) => resolver.port_name(*id).to_string(),
+        HirExpression::Variable(id) => resolver.variable_name(*id).to_string(),
+        HirExpression::Constant(id) => resolver.constant_name(*id).to_string(),
+        HirExpression::GenericParam(name) => name.clone(),
+        HirExpression::Binary(bin) => {
+            let left = emit_expression_inline(&bin.left, resolver);
+            let right = emit_expression_inline(&bin.right, resolver);
+            let op = emit_binary_op(&bin.op);
+            format!("({left} {op} {right})")
+        }
+        HirExpression::Unary(un) => {
+            let operand = emit_expression_inline(&un.operand, resolver);
+            let op = match un.op {
+                HirUnaryOp::Not => "!",
+                HirUnaryOp::Negate => "-",
+                HirUnaryOp::BitwiseNot => "~",
+                HirUnaryOp::AndReduce => "&",
+                HirUnaryOp::OrReduce => "|",
+                HirUnaryOp::XorReduce => "^",
+            };
+            format!("{op}{operand}")
+        }
+        HirExpression::Call(call) => {
+            let args: Vec<_> = call
+                .args
+                .iter()
+                .map(|a| emit_expression_inline(a, resolver))
+                .collect();
+            format!("{}({})", call.function, args.join(", "))
+        }
+        HirExpression::Index(base, idx) => {
+            format!(
+                "{}[{}]",
+                emit_expression_inline(base, resolver),
+                emit_expression_inline(idx, resolver)
+            )
+        }
+        HirExpression::Range(base, lo, hi) => {
+            format!(
+                "{}[{}..{}]",
+                emit_expression_inline(base, resolver),
+                emit_expression_inline(lo, resolver),
+                emit_expression_inline(hi, resolver)
+            )
+        }
+        HirExpression::FieldAccess { base, field } => {
+            format!("{}.{field}", emit_expression_inline(base, resolver))
+        }
+        HirExpression::EnumVariant {
+            enum_type, variant, ..
+        } => {
+            format!("{enum_type}::{variant}")
+        }
+        HirExpression::Concat(exprs) => {
+            let parts: Vec<_> = exprs
+                .iter()
+                .map(|e| emit_expression_inline(e, resolver))
+                .collect();
+            format!("{{{}}}", parts.join(", "))
+        }
+        HirExpression::Ternary {
+            condition,
+            true_expr,
+            false_expr,
+        } => {
+            format!(
+                "if ({}) {{ {} }} else {{ {} }}",
+                emit_expression_inline(condition, resolver),
+                emit_expression_inline(true_expr, resolver),
+                emit_expression_inline(false_expr, resolver)
+            )
+        }
+        HirExpression::StructLiteral(sl) => {
+            let fields: Vec<_> = sl
+                .fields
+                .iter()
+                .map(|f| format!("{}: {}", f.name, emit_expression_inline(&f.value, resolver)))
+                .collect();
+            format!("{} {{ {} }}", sl.type_name, fields.join(", "))
+        }
+        HirExpression::ArrayLiteral(elems) => {
+            let parts: Vec<_> = elems
+                .iter()
+                .map(|e| emit_expression_inline(e, resolver))
+                .collect();
+            format!("[{}]", parts.join(", "))
+        }
+        HirExpression::ArrayRepeat { value, count } => {
+            format!(
+                "[{}; {}]",
+                emit_expression_inline(value, resolver),
+                emit_expression_inline(count, resolver)
+            )
+        }
+        HirExpression::TupleLiteral(elems) => {
+            let parts: Vec<_> = elems
+                .iter()
+                .map(|e| emit_expression_inline(e, resolver))
+                .collect();
+            format!("({})", parts.join(", "))
+        }
+        HirExpression::Cast(cast) => {
+            format!(
+                "{} as {}",
+                emit_expression_inline(&cast.expr, resolver),
+                emit_type_inline(&cast.target_type)
+            )
+        }
+        HirExpression::AssociatedConstant {
+            type_name,
+            constant_name,
+        } => {
+            format!("{type_name}::{constant_name}")
+        }
+        HirExpression::If(if_expr) => {
+            format!(
+                "if ({}) {{ {} }} else {{ {} }}",
+                emit_expression_inline(&if_expr.condition, resolver),
+                emit_expression_inline(&if_expr.then_expr, resolver),
+                emit_expression_inline(&if_expr.else_expr, resolver)
+            )
+        }
+        HirExpression::Match(match_expr) => {
+            let mut s = format!(
+                "match {} {{ ",
+                emit_expression_inline(&match_expr.expr, resolver)
+            );
+            for arm in &match_expr.arms {
+                write!(
+                    s,
+                    "{} => {}, ",
+                    emit_pattern(&arm.pattern),
+                    emit_expression_inline(&arm.expr, resolver)
+                )
+                .unwrap();
+            }
+            s.push('}');
+            s
+        }
+        HirExpression::Block {
+            statements,
+            result_expr,
+        } => {
+            // For inline emission, just show the result expression
+            let _ = statements;
+            emit_expression_inline(result_expr, resolver)
+        }
+    }
+}
+
+fn emit_binary_op(op: &HirBinaryOp) -> &'static str {
+    match op {
+        HirBinaryOp::Add => "+",
+        HirBinaryOp::WidenAdd => "+:",
+        HirBinaryOp::Sub => "-",
+        HirBinaryOp::Mul => "*",
+        HirBinaryOp::Div => "/",
+        HirBinaryOp::Mod => "%",
+        HirBinaryOp::And => "&",
+        HirBinaryOp::Or => "|",
+        HirBinaryOp::Xor => "^",
+        HirBinaryOp::Equal => "==",
+        HirBinaryOp::NotEqual => "!=",
+        HirBinaryOp::Less => "<",
+        HirBinaryOp::LessEqual => "<=",
+        HirBinaryOp::Greater => ">",
+        HirBinaryOp::GreaterEqual => ">=",
+        HirBinaryOp::LogicalAnd => "&&",
+        HirBinaryOp::LogicalOr => "||",
+        HirBinaryOp::LeftShift => "<<",
+        HirBinaryOp::RightShift => ">>",
+    }
+}
+
+pub(crate) fn emit_type(ty: &HirType, _resolver: &NameResolver) -> String {
+    emit_type_inline(ty)
+}
+
+pub(crate) fn emit_type_inline(ty: &HirType) -> String {
+    match ty {
+        HirType::Bit(1) => "bit".to_string(),
+        HirType::Bit(n) => format!("bit[{n}]"),
+        HirType::Bool => "bool".to_string(),
+        HirType::String => "string".to_string(),
+        HirType::Logic(1) => "logic".to_string(),
+        HirType::Logic(n) => format!("logic[{n}]"),
+        HirType::Int(n) => format!("int[{n}]"),
+        HirType::Nat(n) => format!("nat[{n}]"),
+        HirType::Ncl(n) => format!("ncl[{n}]"),
+        HirType::Clock(_) => "clock".to_string(),
+        HirType::Reset { polarity, .. } => match polarity {
+            HirResetPolarity::ActiveHigh => "reset(active_high)".to_string(),
+            HirResetPolarity::ActiveLow => "reset(active_low)".to_string(),
+        },
+        HirType::Event => "event".to_string(),
+        HirType::Stream(inner) => format!("stream<{}>", emit_type_inline(inner)),
+        HirType::Array(inner, n) => format!("[{}; {n}]", emit_type_inline(inner)),
+        HirType::Custom(name) => name.clone(),
+        HirType::Struct(s) => s.name.clone(),
+        HirType::Enum(e) => e.name.clone(),
+        HirType::Union(u) => u.name.clone(),
+        HirType::BitParam(p) => format!("bit[{p}]"),
+        HirType::LogicParam(p) => format!("logic[{p}]"),
+        HirType::IntParam(p) => format!("int[{p}]"),
+        HirType::NatParam(p) => format!("nat[{p}]"),
+        HirType::NclParam(p) => format!("ncl[{p}]"),
+        HirType::BitExpr(e) => format!(
+            "bit[{}]",
+            emit_expression_inline(e, &NameResolver::from_empty())
+        ),
+        HirType::LogicExpr(e) => format!(
+            "logic[{}]",
+            emit_expression_inline(e, &NameResolver::from_empty())
+        ),
+        HirType::IntExpr(e) => format!(
+            "int[{}]",
+            emit_expression_inline(e, &NameResolver::from_empty())
+        ),
+        HirType::NatExpr(e) => format!(
+            "nat[{}]",
+            emit_expression_inline(e, &NameResolver::from_empty())
+        ),
+        HirType::NclExpr(e) => format!(
+            "ncl[{}]",
+            emit_expression_inline(e, &NameResolver::from_empty())
+        ),
+        HirType::ArrayExpr(inner, size) => format!(
+            "[{}; {}]",
+            emit_type_inline(inner),
+            emit_expression_inline(size, &NameResolver::from_empty())
+        ),
+        HirType::Float16 => "fp16".to_string(),
+        HirType::Float32 => "fp32".to_string(),
+        HirType::Float64 => "fp64".to_string(),
+        HirType::Vec2(inner) => format!("vec2<{}>", emit_type_inline(inner)),
+        HirType::Vec3(inner) => format!("vec3<{}>", emit_type_inline(inner)),
+        HirType::Vec4(inner) => format!("vec4<{}>", emit_type_inline(inner)),
+        HirType::FpParametric { format } => format!(
+            "fp<{}>",
+            emit_expression_inline(format, &NameResolver::from_empty())
+        ),
+        HirType::FixedParametric {
+            width,
+            frac,
+            signed,
+        } => format!(
+            "fixed<{}, {}, {}>",
+            emit_expression_inline(width, &NameResolver::from_empty()),
+            emit_expression_inline(frac, &NameResolver::from_empty()),
+            emit_expression_inline(signed, &NameResolver::from_empty())
+        ),
+        HirType::IntParametric { width, signed } => format!(
+            "int<{}, {}>",
+            emit_expression_inline(width, &NameResolver::from_empty()),
+            emit_expression_inline(signed, &NameResolver::from_empty())
+        ),
+        HirType::VecParametric {
+            element_type,
+            dimension,
+        } => format!(
+            "vec<{}, {}>",
+            emit_type_inline(element_type),
+            emit_expression_inline(dimension, &NameResolver::from_empty())
+        ),
+        HirType::Tuple(types) => {
+            let parts: Vec<_> = types.iter().map(emit_type_inline).collect();
+            format!("({})", parts.join(", "))
+        }
+    }
+}
+
+fn emit_lvalue(lval: &HirLValue, resolver: &NameResolver) -> String {
+    match lval {
+        HirLValue::Signal(id) => resolver.signal_name(*id).to_string(),
+        HirLValue::Variable(id) => resolver.variable_name(*id).to_string(),
+        HirLValue::Port(id) => resolver.port_name(*id).to_string(),
+        HirLValue::Index(base, idx) => {
+            format!(
+                "{}[{}]",
+                emit_lvalue(base, resolver),
+                emit_expression_inline(idx, resolver)
+            )
+        }
+        HirLValue::Range(base, lo, hi) => {
+            format!(
+                "{}[{}..{}]",
+                emit_lvalue(base, resolver),
+                emit_expression_inline(lo, resolver),
+                emit_expression_inline(hi, resolver)
+            )
+        }
+        HirLValue::FieldAccess { base, field } => {
+            format!("{}.{field}", emit_lvalue(base, resolver))
+        }
+    }
+}

--- a/crates/skalp-hir-codegen/src/sv_emit.rs
+++ b/crates/skalp-hir-codegen/src/sv_emit.rs
@@ -1,0 +1,601 @@
+//! HIR → SystemVerilog source code emitter
+
+use crate::skalp_emit::emit_expression_inline as sk_expr;
+use crate::{emit_comments, indent, NameResolver};
+use anyhow::Result;
+use skalp_frontend::hir::*;
+use std::fmt::Write;
+
+pub(crate) fn emit_file(hir: &Hir, resolver: &NameResolver) -> Result<String> {
+    let mut out = String::new();
+
+    emit_comments(&mut out, &hir.comments, "//", "");
+
+    for (i, entity) in hir.entities.iter().enumerate() {
+        // Find matching implementation
+        let imp = hir
+            .implementations
+            .iter()
+            .find(|imp| imp.entity == entity.id);
+        emit_module(&mut out, entity, imp, resolver);
+
+        if i + 1 < hir.entities.len() {
+            writeln!(out).unwrap();
+        }
+    }
+
+    Ok(out)
+}
+
+fn emit_module(
+    out: &mut String,
+    entity: &HirEntity,
+    imp: Option<&HirImplementation>,
+    resolver: &NameResolver,
+) {
+    emit_comments(out, &entity.comments, "//", "");
+
+    write!(out, "module {}", entity.name).unwrap();
+
+    // Parameters
+    if !entity.generics.is_empty() {
+        let params: Vec<_> = entity
+            .generics
+            .iter()
+            .filter(|g| {
+                matches!(
+                    g.param_type,
+                    HirGenericType::Const(_) | HirGenericType::Width
+                )
+            })
+            .collect();
+        if !params.is_empty() {
+            writeln!(out, " #(").unwrap();
+            for (i, generic) in params.iter().enumerate() {
+                let ind = indent(1);
+                let ty = match &generic.param_type {
+                    HirGenericType::Const(t) => emit_sv_param_type(t),
+                    _ => "int".to_string(),
+                };
+                let sep = if i + 1 < params.len() { "," } else { "" };
+                if let Some(ref default) = generic.default_value {
+                    writeln!(
+                        out,
+                        "{ind}parameter {ty} {} = {}{sep}",
+                        generic.name,
+                        emit_expr(default, resolver)
+                    )
+                    .unwrap();
+                } else {
+                    writeln!(out, "{ind}parameter {ty} {}{sep}", generic.name).unwrap();
+                }
+            }
+            out.push(')');
+        }
+    }
+
+    // Ports
+    if !entity.ports.is_empty() {
+        writeln!(out, " (").unwrap();
+        for (i, port) in entity.ports.iter().enumerate() {
+            emit_comments(out, &port.comments, "//", &indent(1));
+            let ind = indent(1);
+            let dir = match port.direction {
+                HirPortDirection::Input => "input",
+                HirPortDirection::Output => "output",
+                HirPortDirection::Bidirectional => "inout",
+                HirPortDirection::Protocol => "inout",
+            };
+            let ty = emit_type(&port.port_type);
+            let sep = if i + 1 < entity.ports.len() { "," } else { "" };
+            writeln!(out, "{ind}{dir} {ty} {}{sep}", port.name).unwrap();
+        }
+        writeln!(out, ");").unwrap();
+    } else {
+        writeln!(out, ";").unwrap();
+    }
+
+    writeln!(out).unwrap();
+
+    // Module body
+    if let Some(imp) = imp {
+        // Signal declarations
+        for signal in &imp.signals {
+            let ind = indent(1);
+            emit_comments(out, &signal.comments, "//", &ind);
+            let ty = emit_type(&signal.signal_type);
+            if let Some(ref init) = signal.initial_value {
+                writeln!(
+                    out,
+                    "{ind}{ty} {} = {};",
+                    signal.name,
+                    emit_expr(init, resolver)
+                )
+                .unwrap();
+            } else {
+                writeln!(out, "{ind}{ty} {};", signal.name).unwrap();
+            }
+        }
+
+        // Constants
+        for constant in &imp.constants {
+            let ind = indent(1);
+            emit_comments(out, &constant.comments, "//", &ind);
+            let ty = emit_type(&constant.const_type);
+            writeln!(
+                out,
+                "{ind}localparam {ty} {} = {};",
+                constant.name,
+                emit_expr(&constant.value, resolver)
+            )
+            .unwrap();
+        }
+
+        if !imp.signals.is_empty() || !imp.constants.is_empty() {
+            writeln!(out).unwrap();
+        }
+
+        // Continuous assignments
+        for assign in &imp.assignments {
+            let ind = indent(1);
+            emit_comments(out, &assign.comments, "//", &ind);
+            let lhs = emit_lvalue(&assign.lhs, resolver);
+            let rhs = emit_expr(&assign.rhs, resolver);
+            writeln!(out, "{ind}assign {lhs} = {rhs};").unwrap();
+        }
+
+        // Instances
+        for inst in &imp.instances {
+            emit_sv_instance(out, inst, resolver, 1);
+        }
+
+        // Event blocks (always blocks)
+        for eb in &imp.event_blocks {
+            emit_always_block(out, eb, resolver, 1);
+        }
+    }
+
+    writeln!(out, "endmodule").unwrap();
+}
+
+fn emit_always_block(out: &mut String, eb: &HirEventBlock, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &eb.comments, "//", &ind);
+
+    // Determine always type from triggers
+    let has_clock_edge = eb
+        .triggers
+        .iter()
+        .any(|t| matches!(t.edge, HirEdgeType::Rising | HirEdgeType::Falling));
+
+    if has_clock_edge {
+        // Build sensitivity list
+        let sens: Vec<String> = eb
+            .triggers
+            .iter()
+            .map(|t| {
+                let sig = match &t.signal {
+                    HirEventSignal::Port(id) => resolver.port_name(*id).to_string(),
+                    HirEventSignal::Signal(id) => resolver.signal_name(*id).to_string(),
+                };
+                let edge = match t.edge {
+                    HirEdgeType::Rising | HirEdgeType::Active => "posedge",
+                    HirEdgeType::Falling | HirEdgeType::Inactive => "negedge",
+                    _ => "posedge",
+                };
+                format!("{edge} {sig}")
+            })
+            .collect();
+
+        writeln!(out, "{ind}always_ff @({}) begin", sens.join(" or ")).unwrap();
+    } else {
+        writeln!(out, "{ind}always_comb begin").unwrap();
+    }
+
+    for stmt in &eb.statements {
+        emit_sv_statement(out, stmt, resolver, level + 1, has_clock_edge);
+    }
+
+    writeln!(out, "{ind}end").unwrap();
+}
+
+fn emit_sv_instance(out: &mut String, inst: &HirInstance, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &inst.comments, "//", &ind);
+    let entity_name = resolver.entity_name(inst.entity);
+
+    write!(out, "{ind}{entity_name}").unwrap();
+
+    // Parameter overrides
+    if !inst.generic_args.is_empty() || !inst.named_generic_args.is_empty() {
+        out.push_str(" #(\n");
+        let mut args: Vec<String> = Vec::new();
+        for (name, arg) in &inst.named_generic_args {
+            args.push(format!(".{name}({})", emit_expr(arg, resolver)));
+        }
+        // Positional args (less common in SV)
+        for arg in &inst.generic_args {
+            args.push(emit_expr(arg, resolver));
+        }
+        for (i, arg) in args.iter().enumerate() {
+            let sep = if i + 1 < args.len() { "," } else { "" };
+            writeln!(out, "{ind}    {arg}{sep}").unwrap();
+        }
+        write!(out, "{ind})").unwrap();
+    }
+
+    write!(out, " {}", inst.name).unwrap();
+
+    // Port connections
+    if !inst.connections.is_empty() {
+        writeln!(out, " (").unwrap();
+        for (i, conn) in inst.connections.iter().enumerate() {
+            let sep = if i + 1 < inst.connections.len() {
+                ","
+            } else {
+                ""
+            };
+            writeln!(
+                out,
+                "{ind}    .{}({}){sep}",
+                conn.port,
+                emit_expr(&conn.expr, resolver)
+            )
+            .unwrap();
+        }
+        writeln!(out, "{ind});").unwrap();
+    } else {
+        writeln!(out, "();").unwrap();
+    }
+}
+
+fn emit_sv_statement(
+    out: &mut String,
+    stmt: &HirStatement,
+    resolver: &NameResolver,
+    level: usize,
+    is_sequential: bool,
+) {
+    let ind = indent(level);
+    match stmt {
+        HirStatement::Assignment(assign) => {
+            emit_comments(out, &assign.comments, "//", &ind);
+            let lhs = emit_lvalue(&assign.lhs, resolver);
+            let rhs = emit_expr(&assign.rhs, resolver);
+            let op = if is_sequential { "<=" } else { "=" };
+            writeln!(out, "{ind}{lhs} {op} {rhs};").unwrap();
+        }
+        HirStatement::If(if_stmt) => {
+            let cond = emit_expr(&if_stmt.condition, resolver);
+            writeln!(out, "{ind}if ({cond}) begin").unwrap();
+            for s in &if_stmt.then_statements {
+                emit_sv_statement(out, s, resolver, level + 1, is_sequential);
+            }
+            if let Some(ref else_stmts) = if_stmt.else_statements {
+                writeln!(out, "{ind}end else begin").unwrap();
+                for s in else_stmts {
+                    emit_sv_statement(out, s, resolver, level + 1, is_sequential);
+                }
+            }
+            writeln!(out, "{ind}end").unwrap();
+        }
+        HirStatement::Match(match_stmt) => {
+            let expr = emit_expr(&match_stmt.expr, resolver);
+            writeln!(out, "{ind}case ({expr})").unwrap();
+            for arm in &match_stmt.arms {
+                let pat = emit_sv_pattern(&arm.pattern);
+                writeln!(out, "{ind}    {pat}: begin").unwrap();
+                for s in &arm.statements {
+                    emit_sv_statement(out, s, resolver, level + 2, is_sequential);
+                }
+                writeln!(out, "{ind}    end").unwrap();
+            }
+            writeln!(out, "{ind}endcase").unwrap();
+        }
+        HirStatement::Let(let_stmt) => {
+            let ty = emit_type(&let_stmt.var_type);
+            let val = emit_expr(&let_stmt.value, resolver);
+            writeln!(out, "{ind}{ty} {} = {val};", let_stmt.name).unwrap();
+        }
+        HirStatement::Return(expr) => {
+            if let Some(ref e) = expr {
+                writeln!(out, "{ind}return {};", emit_expr(e, resolver)).unwrap();
+            } else {
+                writeln!(out, "{ind}return;").unwrap();
+            }
+        }
+        HirStatement::Expression(expr) => {
+            writeln!(out, "{ind}{};", emit_expr(expr, resolver)).unwrap();
+        }
+        HirStatement::For(for_stmt) => {
+            let start = emit_expr(&for_stmt.range.start, resolver);
+            let end = emit_expr(&for_stmt.range.end, resolver);
+            let op = if for_stmt.range.inclusive { "<=" } else { "<" };
+            writeln!(
+                out,
+                "{ind}for (int {} = {start}; {} {op} {end}; {}++) begin",
+                for_stmt.iterator, for_stmt.iterator, for_stmt.iterator
+            )
+            .unwrap();
+            for s in &for_stmt.body {
+                emit_sv_statement(out, s, resolver, level + 1, is_sequential);
+            }
+            writeln!(out, "{ind}end").unwrap();
+        }
+        HirStatement::Block(stmts) => {
+            writeln!(out, "{ind}begin").unwrap();
+            for s in stmts {
+                emit_sv_statement(out, s, resolver, level + 1, is_sequential);
+            }
+            writeln!(out, "{ind}end").unwrap();
+        }
+        HirStatement::GenerateFor(gen) => {
+            let start = emit_expr(&gen.range.start, resolver);
+            let end = emit_expr(&gen.range.end, resolver);
+            let op = if gen.range.inclusive { "<=" } else { "<" };
+            writeln!(
+                out,
+                "{ind}for (genvar {} = {start}; {} {op} {end}; {}++) begin",
+                gen.iterator, gen.iterator, gen.iterator
+            )
+            .unwrap();
+            emit_sv_generate_body(out, &gen.body, resolver, level + 1);
+            writeln!(out, "{ind}end").unwrap();
+        }
+        HirStatement::GenerateIf(gen) => {
+            let cond = emit_expr(&gen.condition, resolver);
+            writeln!(out, "{ind}if ({cond}) begin").unwrap();
+            emit_sv_generate_body(out, &gen.then_body, resolver, level + 1);
+            if let Some(ref else_body) = gen.else_body {
+                writeln!(out, "{ind}end else begin").unwrap();
+                emit_sv_generate_body(out, else_body, resolver, level + 1);
+            }
+            writeln!(out, "{ind}end").unwrap();
+        }
+        _ => {
+            writeln!(out, "{ind}// unsupported statement").unwrap();
+        }
+    }
+}
+
+fn emit_sv_generate_body(
+    out: &mut String,
+    body: &HirGenerateBody,
+    resolver: &NameResolver,
+    level: usize,
+) {
+    for signal in &body.signals {
+        let ind = indent(level);
+        emit_comments(out, &signal.comments, "//", &ind);
+        let ty = emit_type(&signal.signal_type);
+        writeln!(out, "{ind}{ty} {};", signal.name).unwrap();
+    }
+    for inst in &body.instances {
+        emit_sv_instance(out, inst, resolver, level);
+    }
+    for eb in &body.event_blocks {
+        emit_always_block(out, eb, resolver, level);
+    }
+    for assign in &body.assignments {
+        let ind = indent(level);
+        emit_comments(out, &assign.comments, "//", &ind);
+        let lhs = emit_lvalue(&assign.lhs, resolver);
+        let rhs = emit_expr(&assign.rhs, resolver);
+        writeln!(out, "{ind}assign {lhs} = {rhs};").unwrap();
+    }
+    for stmt in &body.generate_stmts {
+        emit_sv_statement(out, stmt, resolver, level, false);
+    }
+}
+
+fn emit_sv_pattern(pat: &HirPattern) -> String {
+    match pat {
+        HirPattern::Literal(lit) => emit_sv_literal(lit),
+        HirPattern::Variable(_) => "default".to_string(),
+        HirPattern::Wildcard => "default".to_string(),
+        HirPattern::Tuple(_) => "default".to_string(),
+        HirPattern::Path(_, variant) => variant.clone(),
+    }
+}
+
+fn emit_sv_literal(lit: &HirLiteral) -> String {
+    match lit {
+        HirLiteral::Integer(n) => n.to_string(),
+        HirLiteral::Boolean(b) => {
+            if *b {
+                "1'b1".to_string()
+            } else {
+                "1'b0".to_string()
+            }
+        }
+        HirLiteral::Float(f) => format!("{f}"),
+        HirLiteral::String(s) => format!("\"{s}\""),
+        HirLiteral::BitVector(bits) => {
+            let width = bits.len();
+            let mut s = format!("{width}'b");
+            for b in bits {
+                s.push(if *b { '1' } else { '0' });
+            }
+            s
+        }
+    }
+}
+
+fn emit_expr(expr: &HirExpression, resolver: &NameResolver) -> String {
+    match expr {
+        HirExpression::Literal(lit) => emit_sv_literal(lit),
+        HirExpression::Signal(id) => resolver.signal_name(*id).to_string(),
+        HirExpression::Port(id) => resolver.port_name(*id).to_string(),
+        HirExpression::Variable(id) => resolver.variable_name(*id).to_string(),
+        HirExpression::Constant(id) => resolver.constant_name(*id).to_string(),
+        HirExpression::GenericParam(name) => name.clone(),
+        HirExpression::Binary(bin) => {
+            let left = emit_expr(&bin.left, resolver);
+            let right = emit_expr(&bin.right, resolver);
+            let op = emit_sv_binary_op(&bin.op);
+            format!("({left} {op} {right})")
+        }
+        HirExpression::Unary(un) => {
+            let operand = emit_expr(&un.operand, resolver);
+            let op = match un.op {
+                HirUnaryOp::Not => "!",
+                HirUnaryOp::Negate => "-",
+                HirUnaryOp::BitwiseNot => "~",
+                HirUnaryOp::AndReduce => "&",
+                HirUnaryOp::OrReduce => "|",
+                HirUnaryOp::XorReduce => "^",
+            };
+            format!("{op}{operand}")
+        }
+        HirExpression::Call(call) => {
+            let args: Vec<_> = call.args.iter().map(|a| emit_expr(a, resolver)).collect();
+            format!("{}({})", call.function, args.join(", "))
+        }
+        HirExpression::Index(base, idx) => {
+            format!(
+                "{}[{}]",
+                emit_expr(base, resolver),
+                emit_expr(idx, resolver)
+            )
+        }
+        HirExpression::Range(base, lo, hi) => {
+            format!(
+                "{}[{}:{}]",
+                emit_expr(base, resolver),
+                emit_expr(hi, resolver),
+                emit_expr(lo, resolver)
+            )
+        }
+        HirExpression::FieldAccess { base, field } => {
+            format!("{}.{field}", emit_expr(base, resolver))
+        }
+        HirExpression::EnumVariant { variant, .. } => variant.clone(),
+        HirExpression::Concat(exprs) => {
+            let parts: Vec<_> = exprs.iter().map(|e| emit_expr(e, resolver)).collect();
+            format!("{{{}}}", parts.join(", "))
+        }
+        HirExpression::Ternary {
+            condition,
+            true_expr,
+            false_expr,
+        } => {
+            format!(
+                "({} ? {} : {})",
+                emit_expr(condition, resolver),
+                emit_expr(true_expr, resolver),
+                emit_expr(false_expr, resolver)
+            )
+        }
+        HirExpression::Cast(cast) => emit_sv_cast(&cast.expr, &cast.target_type, resolver),
+        HirExpression::ArrayRepeat { value, count } => {
+            format!(
+                "'{{{} {{{}}}}}",
+                emit_expr(count, resolver),
+                emit_expr(value, resolver)
+            )
+        }
+        _ => sk_expr(expr, resolver),
+    }
+}
+
+fn emit_sv_cast(expr: &HirExpression, target: &HirType, resolver: &NameResolver) -> String {
+    let inner = emit_expr(expr, resolver);
+    match target {
+        HirType::Int(n) => format!("$signed({n}'({inner}))"),
+        HirType::Nat(n) => format!("{n}'({inner})"),
+        _ => inner,
+    }
+}
+
+fn emit_sv_binary_op(op: &HirBinaryOp) -> &'static str {
+    match op {
+        HirBinaryOp::Add => "+",
+        HirBinaryOp::WidenAdd => "+",
+        HirBinaryOp::Sub => "-",
+        HirBinaryOp::Mul => "*",
+        HirBinaryOp::Div => "/",
+        HirBinaryOp::Mod => "%",
+        HirBinaryOp::And => "&",
+        HirBinaryOp::Or => "|",
+        HirBinaryOp::Xor => "^",
+        HirBinaryOp::Equal => "==",
+        HirBinaryOp::NotEqual => "!=",
+        HirBinaryOp::Less => "<",
+        HirBinaryOp::LessEqual => "<=",
+        HirBinaryOp::Greater => ">",
+        HirBinaryOp::GreaterEqual => ">=",
+        HirBinaryOp::LogicalAnd => "&&",
+        HirBinaryOp::LogicalOr => "||",
+        HirBinaryOp::LeftShift => "<<",
+        HirBinaryOp::RightShift => ">>",
+    }
+}
+
+fn emit_type(ty: &HirType) -> String {
+    match ty {
+        HirType::Bit(1) => "logic".to_string(),
+        HirType::Bit(n) => format!("logic [{n_1}:0]", n_1 = n - 1),
+        HirType::Bool => "logic".to_string(),
+        HirType::Logic(1) => "logic".to_string(),
+        HirType::Logic(n) => format!("logic [{n_1}:0]", n_1 = n - 1),
+        HirType::Int(n) => format!("logic signed [{n_1}:0]", n_1 = n - 1),
+        HirType::Nat(n) => format!("logic [{n_1}:0]", n_1 = n - 1),
+        HirType::Clock(_) => "logic".to_string(),
+        HirType::Reset { .. } => "logic".to_string(),
+        HirType::Array(inner, n) => format!("{} [0:{}]", emit_type(inner), n - 1),
+        HirType::Custom(name) => name.clone(),
+        HirType::Struct(s) => s.name.clone(),
+        HirType::Enum(e) => e.name.clone(),
+        HirType::BitParam(p) => format!("logic [{p}-1:0]"),
+        HirType::NatParam(p) => format!("logic [{p}-1:0]"),
+        HirType::IntParam(p) => format!("logic signed [{p}-1:0]"),
+        HirType::LogicParam(p) => format!("logic [{p}-1:0]"),
+        HirType::BitExpr(e) => {
+            let w = sk_expr(e, &NameResolver::from_empty());
+            format!("logic [{w}-1:0]")
+        }
+        HirType::NatExpr(e) => {
+            let w = sk_expr(e, &NameResolver::from_empty());
+            format!("logic [{w}-1:0]")
+        }
+        HirType::IntExpr(e) => {
+            let w = sk_expr(e, &NameResolver::from_empty());
+            format!("logic signed [{w}-1:0]")
+        }
+        _ => format!("logic /* unsupported: {:?} */", ty),
+    }
+}
+
+fn emit_sv_param_type(ty: &HirType) -> String {
+    match ty {
+        HirType::Nat(_) | HirType::Int(_) => "int".to_string(),
+        HirType::Bool => "bit".to_string(),
+        _ => "int".to_string(),
+    }
+}
+
+fn emit_lvalue(lval: &HirLValue, resolver: &NameResolver) -> String {
+    match lval {
+        HirLValue::Signal(id) => resolver.signal_name(*id).to_string(),
+        HirLValue::Variable(id) => resolver.variable_name(*id).to_string(),
+        HirLValue::Port(id) => resolver.port_name(*id).to_string(),
+        HirLValue::Index(base, idx) => {
+            format!(
+                "{}[{}]",
+                emit_lvalue(base, resolver),
+                emit_expr(idx, resolver)
+            )
+        }
+        HirLValue::Range(base, lo, hi) => {
+            format!(
+                "{}[{}:{}]",
+                emit_lvalue(base, resolver),
+                emit_expr(hi, resolver),
+                emit_expr(lo, resolver)
+            )
+        }
+        HirLValue::FieldAccess { base, field } => {
+            format!("{}.{field}", emit_lvalue(base, resolver))
+        }
+    }
+}

--- a/crates/skalp-hir-codegen/src/vhdl_emit.rs
+++ b/crates/skalp-hir-codegen/src/vhdl_emit.rs
@@ -1,0 +1,580 @@
+//! HIR → VHDL source code emitter
+
+use crate::skalp_emit::emit_expression_inline as sk_expr;
+use crate::{emit_comments, indent, NameResolver};
+use anyhow::Result;
+use skalp_frontend::hir::*;
+use std::fmt::Write;
+
+pub(crate) fn emit_file(hir: &Hir, resolver: &NameResolver) -> Result<String> {
+    let mut out = String::new();
+
+    emit_comments(&mut out, &hir.comments, "--", "");
+
+    // IEEE library preamble
+    writeln!(out, "library ieee;")?;
+    writeln!(out, "use ieee.std_logic_1164.all;")?;
+    writeln!(out, "use ieee.numeric_std.all;")?;
+    writeln!(out)?;
+
+    for (i, entity) in hir.entities.iter().enumerate() {
+        emit_entity(&mut out, entity, resolver);
+
+        // Find matching implementation
+        if let Some(imp) = hir
+            .implementations
+            .iter()
+            .find(|imp| imp.entity == entity.id)
+        {
+            writeln!(out).unwrap();
+            emit_architecture(&mut out, imp, entity, resolver);
+        }
+
+        if i + 1 < hir.entities.len() {
+            writeln!(out).unwrap();
+        }
+    }
+
+    Ok(out)
+}
+
+fn emit_entity(out: &mut String, entity: &HirEntity, resolver: &NameResolver) {
+    emit_comments(out, &entity.comments, "--", "");
+
+    write!(out, "entity {} is", entity.name).unwrap();
+
+    // Generics
+    if !entity.generics.is_empty() {
+        writeln!(out).unwrap();
+        writeln!(out, "    generic (").unwrap();
+        let generics: Vec<_> = entity
+            .generics
+            .iter()
+            .filter(|g| {
+                matches!(
+                    g.param_type,
+                    HirGenericType::Const(_) | HirGenericType::Width
+                )
+            })
+            .collect();
+        for (i, generic) in generics.iter().enumerate() {
+            let ty = match &generic.param_type {
+                HirGenericType::Width => "natural".to_string(),
+                HirGenericType::Const(t) => emit_type(t),
+                _ => "natural".to_string(),
+            };
+            let sep = if i + 1 < generics.len() { ";" } else { "" };
+            let ind = indent(2);
+            if let Some(ref default) = generic.default_value {
+                writeln!(
+                    out,
+                    "{ind}{} : {ty} := {}{sep}",
+                    generic.name,
+                    emit_expr(default, resolver)
+                )
+                .unwrap();
+            } else {
+                writeln!(out, "{ind}{} : {ty}{sep}", generic.name).unwrap();
+            }
+        }
+        writeln!(out, "    );").unwrap();
+    }
+
+    // Ports
+    if !entity.ports.is_empty() {
+        writeln!(out).unwrap();
+        writeln!(out, "    port (").unwrap();
+        for (i, port) in entity.ports.iter().enumerate() {
+            emit_comments(out, &port.comments, "--", &indent(2));
+            let ind = indent(2);
+            let dir = match port.direction {
+                HirPortDirection::Input => "in",
+                HirPortDirection::Output => "out",
+                HirPortDirection::Bidirectional => "inout",
+                HirPortDirection::Protocol => "inout",
+            };
+            let ty = emit_type(&port.port_type);
+            let sep = if i + 1 < entity.ports.len() { ";" } else { "" };
+            writeln!(out, "{ind}{} : {dir} {ty}{sep}", port.name).unwrap();
+        }
+        writeln!(out, "    );").unwrap();
+    }
+
+    writeln!(out, "end entity {};", entity.name).unwrap();
+}
+
+fn emit_architecture(
+    out: &mut String,
+    imp: &HirImplementation,
+    entity: &HirEntity,
+    resolver: &NameResolver,
+) {
+    writeln!(out, "architecture rtl of {} is", entity.name).unwrap();
+
+    // Signal declarations
+    for signal in &imp.signals {
+        let ind = indent(1);
+        emit_comments(out, &signal.comments, "--", &ind);
+        let ty = emit_type(&signal.signal_type);
+        if let Some(ref init) = signal.initial_value {
+            writeln!(
+                out,
+                "{ind}signal {} : {ty} := {};",
+                signal.name,
+                emit_expr(init, resolver)
+            )
+            .unwrap();
+        } else {
+            writeln!(out, "{ind}signal {} : {ty};", signal.name).unwrap();
+        }
+    }
+
+    // Variable declarations
+    for variable in &imp.variables {
+        let ind = indent(1);
+        emit_comments(out, &variable.comments, "--", &ind);
+        let ty = emit_type(&variable.var_type);
+        writeln!(out, "{ind}variable {} : {ty};", variable.name).unwrap();
+    }
+
+    // Constants
+    for constant in &imp.constants {
+        let ind = indent(1);
+        emit_comments(out, &constant.comments, "--", &ind);
+        let ty = emit_type(&constant.const_type);
+        writeln!(
+            out,
+            "{ind}constant {} : {ty} := {};",
+            constant.name,
+            emit_expr(&constant.value, resolver)
+        )
+        .unwrap();
+    }
+
+    writeln!(out, "begin").unwrap();
+
+    // Continuous assignments
+    for assign in &imp.assignments {
+        let ind = indent(1);
+        emit_comments(out, &assign.comments, "--", &ind);
+        let lhs = emit_lvalue(&assign.lhs, resolver);
+        let rhs = emit_expr(&assign.rhs, resolver);
+        writeln!(out, "{ind}{lhs} <= {rhs};").unwrap();
+    }
+
+    // Instances
+    for inst in &imp.instances {
+        emit_instance(out, inst, resolver, 1);
+    }
+
+    // Event blocks (processes)
+    for eb in &imp.event_blocks {
+        emit_process(out, eb, resolver, 1);
+    }
+
+    writeln!(out, "end architecture rtl;").unwrap();
+}
+
+fn emit_process(out: &mut String, eb: &HirEventBlock, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &eb.comments, "--", &ind);
+
+    // Build sensitivity list from triggers
+    let sensitivity: Vec<String> = eb
+        .triggers
+        .iter()
+        .map(|t| match &t.signal {
+            HirEventSignal::Port(id) => resolver.port_name(*id).to_string(),
+            HirEventSignal::Signal(id) => resolver.signal_name(*id).to_string(),
+        })
+        .collect();
+
+    writeln!(out, "{ind}process({})", sensitivity.join(", ")).unwrap();
+    writeln!(out, "{ind}begin").unwrap();
+
+    // Wrap body in edge detection if needed
+    let has_edge = eb
+        .triggers
+        .iter()
+        .any(|t| matches!(t.edge, HirEdgeType::Rising | HirEdgeType::Falling));
+
+    if has_edge {
+        let trigger = &eb.triggers[0];
+        let sig = match &trigger.signal {
+            HirEventSignal::Port(id) => resolver.port_name(*id).to_string(),
+            HirEventSignal::Signal(id) => resolver.signal_name(*id).to_string(),
+        };
+        let edge_fn = match trigger.edge {
+            HirEdgeType::Rising => "rising_edge",
+            HirEdgeType::Falling => "falling_edge",
+            _ => "rising_edge",
+        };
+        let ind2 = indent(level + 1);
+        writeln!(out, "{ind2}if {edge_fn}({sig}) then").unwrap();
+
+        // Check for reset in additional triggers
+        let reset_trigger = eb.triggers.iter().skip(1).find(|t| {
+            matches!(
+                t.edge,
+                HirEdgeType::Active | HirEdgeType::Inactive | HirEdgeType::Rising
+            )
+        });
+
+        if let Some(_reset) = reset_trigger {
+            // Emit reset + body pattern
+            for stmt in &eb.statements {
+                emit_vhdl_statement(out, stmt, resolver, level + 2);
+            }
+        } else {
+            for stmt in &eb.statements {
+                emit_vhdl_statement(out, stmt, resolver, level + 2);
+            }
+        }
+        writeln!(out, "{ind2}end if;").unwrap();
+    } else {
+        for stmt in &eb.statements {
+            emit_vhdl_statement(out, stmt, resolver, level + 1);
+        }
+    }
+
+    writeln!(out, "{ind}end process;").unwrap();
+}
+
+fn emit_instance(out: &mut String, inst: &HirInstance, resolver: &NameResolver, level: usize) {
+    let ind = indent(level);
+    emit_comments(out, &inst.comments, "--", &ind);
+    let entity_name = resolver.entity_name(inst.entity);
+    write!(out, "{ind}{}: entity work.{entity_name}", inst.name).unwrap();
+
+    // Generic map
+    if !inst.generic_args.is_empty() || !inst.named_generic_args.is_empty() {
+        writeln!(out).unwrap();
+        writeln!(out, "{ind}    generic map (").unwrap();
+        let mut args: Vec<String> = Vec::new();
+        for arg in &inst.generic_args {
+            args.push(emit_expr(arg, resolver));
+        }
+        for (name, arg) in &inst.named_generic_args {
+            args.push(format!("{name} => {}", emit_expr(arg, resolver)));
+        }
+        for (i, arg) in args.iter().enumerate() {
+            let sep = if i + 1 < args.len() { "," } else { "" };
+            writeln!(out, "{ind}        {arg}{sep}").unwrap();
+        }
+        writeln!(out, "{ind}    )").unwrap();
+    }
+
+    // Port map
+    if !inst.connections.is_empty() {
+        writeln!(out).unwrap();
+        writeln!(out, "{ind}    port map (").unwrap();
+        for (i, conn) in inst.connections.iter().enumerate() {
+            let sep = if i + 1 < inst.connections.len() {
+                ","
+            } else {
+                ""
+            };
+            writeln!(
+                out,
+                "{ind}        {} => {}{sep}",
+                conn.port,
+                emit_expr(&conn.expr, resolver)
+            )
+            .unwrap();
+        }
+        writeln!(out, "{ind}    );").unwrap();
+    } else {
+        writeln!(out, ";").unwrap();
+    }
+}
+
+fn emit_vhdl_statement(
+    out: &mut String,
+    stmt: &HirStatement,
+    resolver: &NameResolver,
+    level: usize,
+) {
+    let ind = indent(level);
+    match stmt {
+        HirStatement::Assignment(assign) => {
+            emit_comments(out, &assign.comments, "--", &ind);
+            let lhs = emit_lvalue(&assign.lhs, resolver);
+            let rhs = emit_expr(&assign.rhs, resolver);
+            match assign.assignment_type {
+                HirAssignmentType::Combinational => {
+                    writeln!(out, "{ind}{lhs} <= {rhs};").unwrap();
+                }
+                HirAssignmentType::NonBlocking => {
+                    writeln!(out, "{ind}{lhs} <= {rhs};").unwrap();
+                }
+                HirAssignmentType::Blocking => {
+                    writeln!(out, "{ind}{lhs} := {rhs};").unwrap();
+                }
+            }
+        }
+        HirStatement::If(if_stmt) => {
+            let cond = emit_expr(&if_stmt.condition, resolver);
+            writeln!(out, "{ind}if {cond} then").unwrap();
+            for s in &if_stmt.then_statements {
+                emit_vhdl_statement(out, s, resolver, level + 1);
+            }
+            if let Some(ref else_stmts) = if_stmt.else_statements {
+                writeln!(out, "{ind}else").unwrap();
+                for s in else_stmts {
+                    emit_vhdl_statement(out, s, resolver, level + 1);
+                }
+            }
+            writeln!(out, "{ind}end if;").unwrap();
+        }
+        HirStatement::Match(match_stmt) => {
+            let expr = emit_expr(&match_stmt.expr, resolver);
+            writeln!(out, "{ind}case {expr} is").unwrap();
+            for arm in &match_stmt.arms {
+                let pat = emit_vhdl_pattern(&arm.pattern);
+                writeln!(out, "{ind}    when {pat} =>").unwrap();
+                for s in &arm.statements {
+                    emit_vhdl_statement(out, s, resolver, level + 2);
+                }
+            }
+            writeln!(out, "{ind}end case;").unwrap();
+        }
+        HirStatement::Let(let_stmt) => {
+            let ty = emit_type(&let_stmt.var_type);
+            let val = emit_expr(&let_stmt.value, resolver);
+            writeln!(out, "{ind}variable {} : {ty} := {val};", let_stmt.name).unwrap();
+        }
+        HirStatement::Return(expr) => {
+            if let Some(ref e) = expr {
+                writeln!(out, "{ind}return {};", emit_expr(e, resolver)).unwrap();
+            } else {
+                writeln!(out, "{ind}return;").unwrap();
+            }
+        }
+        HirStatement::Expression(expr) => {
+            writeln!(out, "{ind}{};", emit_expr(expr, resolver)).unwrap();
+        }
+        HirStatement::For(for_stmt) => {
+            let start = emit_expr(&for_stmt.range.start, resolver);
+            let end = emit_expr(&for_stmt.range.end, resolver);
+            writeln!(
+                out,
+                "{ind}for {} in {start} to {end} loop",
+                for_stmt.iterator
+            )
+            .unwrap();
+            for s in &for_stmt.body {
+                emit_vhdl_statement(out, s, resolver, level + 1);
+            }
+            writeln!(out, "{ind}end loop;").unwrap();
+        }
+        HirStatement::Block(stmts) => {
+            for s in stmts {
+                emit_vhdl_statement(out, s, resolver, level);
+            }
+        }
+        _ => {
+            writeln!(out, "{ind}-- unsupported statement").unwrap();
+        }
+    }
+}
+
+fn emit_vhdl_pattern(pat: &HirPattern) -> String {
+    match pat {
+        HirPattern::Literal(lit) => emit_vhdl_literal(lit),
+        HirPattern::Variable(_) => "others".to_string(),
+        HirPattern::Wildcard => "others".to_string(),
+        HirPattern::Tuple(_) => "others".to_string(),
+        HirPattern::Path(_, variant) => variant.clone(),
+    }
+}
+
+fn emit_vhdl_literal(lit: &HirLiteral) -> String {
+    match lit {
+        HirLiteral::Integer(n) => n.to_string(),
+        HirLiteral::Boolean(b) => {
+            if *b {
+                "true".to_string()
+            } else {
+                "false".to_string()
+            }
+        }
+        HirLiteral::Float(f) => format!("{f}"),
+        HirLiteral::String(s) => format!("\"{s}\""),
+        HirLiteral::BitVector(bits) => {
+            let mut s = String::from("\"");
+            for b in bits {
+                s.push(if *b { '1' } else { '0' });
+            }
+            s.push('"');
+            s
+        }
+    }
+}
+
+fn emit_expr(expr: &HirExpression, resolver: &NameResolver) -> String {
+    match expr {
+        HirExpression::Literal(lit) => emit_vhdl_literal(lit),
+        HirExpression::Signal(id) => resolver.signal_name(*id).to_string(),
+        HirExpression::Port(id) => resolver.port_name(*id).to_string(),
+        HirExpression::Variable(id) => resolver.variable_name(*id).to_string(),
+        HirExpression::Constant(id) => resolver.constant_name(*id).to_string(),
+        HirExpression::GenericParam(name) => name.clone(),
+        HirExpression::Binary(bin) => {
+            let left = emit_expr(&bin.left, resolver);
+            let right = emit_expr(&bin.right, resolver);
+            let op = emit_vhdl_binary_op(&bin.op);
+            format!("({left} {op} {right})")
+        }
+        HirExpression::Unary(un) => {
+            let operand = emit_expr(&un.operand, resolver);
+            match un.op {
+                HirUnaryOp::Not | HirUnaryOp::BitwiseNot => format!("not {operand}"),
+                HirUnaryOp::Negate => format!("-{operand}"),
+                HirUnaryOp::AndReduce => format!("and_reduce({operand})"),
+                HirUnaryOp::OrReduce => format!("or_reduce({operand})"),
+                HirUnaryOp::XorReduce => format!("xor_reduce({operand})"),
+            }
+        }
+        HirExpression::Call(call) => {
+            let args: Vec<_> = call.args.iter().map(|a| emit_expr(a, resolver)).collect();
+            format!("{}({})", call.function, args.join(", "))
+        }
+        HirExpression::Index(base, idx) => {
+            format!(
+                "{}(to_integer({}))",
+                emit_expr(base, resolver),
+                emit_expr(idx, resolver)
+            )
+        }
+        HirExpression::Range(base, lo, hi) => {
+            format!(
+                "{}({} downto {})",
+                emit_expr(base, resolver),
+                emit_expr(hi, resolver),
+                emit_expr(lo, resolver)
+            )
+        }
+        HirExpression::FieldAccess { base, field } => {
+            format!("{}.{field}", emit_expr(base, resolver))
+        }
+        HirExpression::EnumVariant { variant, .. } => variant.clone(),
+        HirExpression::Concat(exprs) => {
+            let parts: Vec<_> = exprs.iter().map(|e| emit_expr(e, resolver)).collect();
+            parts.join(" & ")
+        }
+        HirExpression::Ternary {
+            condition,
+            true_expr,
+            false_expr,
+        } => {
+            // VHDL doesn't have ternary; use when/else for signal assignments
+            format!(
+                "{} when {} else {}",
+                emit_expr(true_expr, resolver),
+                emit_expr(condition, resolver),
+                emit_expr(false_expr, resolver)
+            )
+        }
+        HirExpression::Cast(cast) => emit_vhdl_cast(&cast.expr, &cast.target_type, resolver),
+        _ => sk_expr(expr, resolver),
+    }
+}
+
+fn emit_vhdl_cast(expr: &HirExpression, target: &HirType, resolver: &NameResolver) -> String {
+    let inner = emit_expr(expr, resolver);
+    match target {
+        HirType::Nat(_) => format!("unsigned({inner})"),
+        HirType::Int(_) => format!("signed({inner})"),
+        HirType::Bit(_) => format!("std_logic_vector({inner})"),
+        _ => inner,
+    }
+}
+
+fn emit_vhdl_binary_op(op: &HirBinaryOp) -> &'static str {
+    match op {
+        HirBinaryOp::Add => "+",
+        HirBinaryOp::WidenAdd => "+",
+        HirBinaryOp::Sub => "-",
+        HirBinaryOp::Mul => "*",
+        HirBinaryOp::Div => "/",
+        HirBinaryOp::Mod => "mod",
+        HirBinaryOp::And => "and",
+        HirBinaryOp::Or => "or",
+        HirBinaryOp::Xor => "xor",
+        HirBinaryOp::Equal => "=",
+        HirBinaryOp::NotEqual => "/=",
+        HirBinaryOp::Less => "<",
+        HirBinaryOp::LessEqual => "<=",
+        HirBinaryOp::Greater => ">",
+        HirBinaryOp::GreaterEqual => ">=",
+        HirBinaryOp::LogicalAnd => "and",
+        HirBinaryOp::LogicalOr => "or",
+        HirBinaryOp::LeftShift => "sll",
+        HirBinaryOp::RightShift => "srl",
+    }
+}
+
+fn emit_type(ty: &HirType) -> String {
+    match ty {
+        HirType::Bit(1) => "std_logic".to_string(),
+        HirType::Bit(n) => format!("std_logic_vector({} downto 0)", n - 1),
+        HirType::Bool => "boolean".to_string(),
+        HirType::String => "string".to_string(),
+        HirType::Logic(1) => "std_logic".to_string(),
+        HirType::Logic(n) => format!("std_logic_vector({} downto 0)", n - 1),
+        HirType::Int(n) => format!("signed({} downto 0)", n - 1),
+        HirType::Nat(n) => format!("unsigned({} downto 0)", n - 1),
+        HirType::Clock(_) => "std_logic".to_string(),
+        HirType::Reset { .. } => "std_logic".to_string(),
+        HirType::Array(inner, n) => {
+            format!("array (0 to {}) of {}", n - 1, emit_type(inner))
+        }
+        HirType::Custom(name) => name.clone(),
+        HirType::Struct(s) => format!("{}_t", s.name.to_lowercase()),
+        HirType::Enum(e) => format!("{}_t", e.name.to_lowercase()),
+        HirType::Union(u) => format!("{}_t", u.name.to_lowercase()),
+        HirType::BitParam(p) => format!("std_logic_vector({p} - 1 downto 0)"),
+        HirType::NatParam(p) => format!("unsigned({p} - 1 downto 0)"),
+        HirType::IntParam(p) => format!("signed({p} - 1 downto 0)"),
+        HirType::LogicParam(p) => format!("std_logic_vector({p} - 1 downto 0)"),
+        HirType::BitExpr(e) => {
+            let w = sk_expr(e, &NameResolver::from_empty());
+            format!("std_logic_vector({w} - 1 downto 0)")
+        }
+        HirType::NatExpr(e) => {
+            let w = sk_expr(e, &NameResolver::from_empty());
+            format!("unsigned({w} - 1 downto 0)")
+        }
+        HirType::IntExpr(e) => {
+            let w = sk_expr(e, &NameResolver::from_empty());
+            format!("signed({w} - 1 downto 0)")
+        }
+        _ => format!("-- unsupported type: {:?}", ty),
+    }
+}
+
+fn emit_lvalue(lval: &HirLValue, resolver: &NameResolver) -> String {
+    match lval {
+        HirLValue::Signal(id) => resolver.signal_name(*id).to_string(),
+        HirLValue::Variable(id) => resolver.variable_name(*id).to_string(),
+        HirLValue::Port(id) => resolver.port_name(*id).to_string(),
+        HirLValue::Index(base, idx) => {
+            format!(
+                "{}(to_integer({}))",
+                emit_lvalue(base, resolver),
+                emit_expr(idx, resolver)
+            )
+        }
+        HirLValue::Range(base, lo, hi) => {
+            format!(
+                "{}({} downto {})",
+                emit_lvalue(base, resolver),
+                emit_expr(hi, resolver),
+                emit_expr(lo, resolver)
+            )
+        }
+        HirLValue::FieldAccess { base, field } => {
+            format!("{}.{field}", emit_lvalue(base, resolver))
+        }
+    }
+}

--- a/crates/skalp-lint/src/lints/hardware.rs
+++ b/crates/skalp-lint/src/lints/hardware.rs
@@ -129,6 +129,7 @@ mod tests {
             body: vec![],
             pipeline_config: None,
             span: None,
+            comments: vec![],
         };
 
         lint.check_function(&func, &mut ctx);

--- a/crates/skalp-lint/src/lints/types.rs
+++ b/crates/skalp-lint/src/lints/types.rs
@@ -109,6 +109,7 @@ mod tests {
             body: vec![],
             pipeline_config: None,
             span: None,
+            comments: vec![],
         };
 
         lint.check_function(&func, &mut ctx);

--- a/crates/skalp-mir/src/hir_to_mir.rs
+++ b/crates/skalp-mir/src/hir_to_mir.rs
@@ -5826,6 +5826,7 @@ impl<'hir> HirToMir<'hir> {
                         var_name,
                         value,
                     ),
+                    comments: vec![],
                 })
             }
             hir::HirStatement::If(if_stmt) => hir::HirStatement::If(hir::HirIfStatement {
@@ -12053,6 +12054,7 @@ impl<'hir> HirToMir<'hir> {
                                     lhs: assign_stmt.lhs.clone(),
                                     rhs: sub_rhs,
                                     assignment_type: assign_stmt.assignment_type.clone(),
+                                    comments: vec![],
                                 },
                             ));
                         }
@@ -14019,6 +14021,7 @@ impl<'hir> HirToMir<'hir> {
                                         lhs: assign_stmt.lhs.clone(),
                                         assignment_type: assign_stmt.assignment_type.clone(),
                                         rhs: rhs_sub,
+                                        comments: vec![],
                                     },
                                 ));
                             }
@@ -14308,6 +14311,7 @@ impl<'hir> HirToMir<'hir> {
                         lhs: assign_stmt.lhs.clone(),
                         assignment_type: assign_stmt.assignment_type.clone(),
                         rhs: rhs_sub,
+                        comments: vec![],
                     }));
                 }
                 other => {
@@ -14586,6 +14590,7 @@ impl<'hir> HirToMir<'hir> {
                                     lhs: assign_stmt.lhs.clone(),
                                     assignment_type: assign_stmt.assignment_type.clone(),
                                     rhs: sub_rhs,
+                                    comments: vec![],
                                 },
                             ));
                         }
@@ -14904,6 +14909,7 @@ impl<'hir> HirToMir<'hir> {
                                     lhs: assign_stmt.lhs.clone(),
                                     assignment_type: assign_stmt.assignment_type.clone(),
                                     rhs: sub_rhs,
+                                    comments: vec![],
                                 },
                             ));
                         }
@@ -15381,6 +15387,7 @@ impl<'hir> HirToMir<'hir> {
                     lhs: assign_stmt.lhs.clone(),
                     assignment_type: assign_stmt.assignment_type.clone(),
                     rhs: sub_rhs,
+                    comments: vec![],
                 })
             }
             _ => stmt.clone(),
@@ -15450,6 +15457,7 @@ impl<'hir> HirToMir<'hir> {
                     lhs: assign_stmt.lhs.clone(),
                     assignment_type: assign_stmt.assignment_type.clone(),
                     rhs: sub_rhs,
+                    comments: vec![],
                 }))
             }
             _ => Some(stmt.clone()),

--- a/crates/skalp-mir/src/monomorphize.rs
+++ b/crates/skalp-mir/src/monomorphize.rs
@@ -874,6 +874,7 @@ impl Monomorphizer {
                 .collect(),
             span: generic_func.span.clone(), // Preserve source span from generic function
             pipeline_config: generic_func.pipeline_config.clone(), // Preserve pipeline config
+            comments: vec![],
         };
 
         self.specialized_functions.push(specialized_func);
@@ -1088,6 +1089,7 @@ impl Monomorphizer {
             body: method_info.body.clone(), // TODO: May need to substitute Self in body too
             span: None,                     // Specialized functions don't have source spans
             pipeline_config: None,          // Trait methods don't have pipeline config
+            comments: vec![],
         };
 
         // Record that we've generated this specialization
@@ -1211,6 +1213,7 @@ impl Monomorphizer {
                     lhs: assign.lhs.clone(),
                     assignment_type: assign.assignment_type.clone(),
                     rhs: self.replace_calls_in_expression(&assign.rhs, ctx),
+                    comments: assign.comments.clone(),
                 })
             }
             hir::HirStatement::Expression(expr) => {

--- a/crates/skalp-mir/tests/hir_to_mir_test.rs
+++ b/crates/skalp-mir/tests/hir_to_mir_test.rs
@@ -8,6 +8,7 @@ use skalp_mir::hir_to_mir::HirToMir;
 fn create_simple_entity() -> Hir {
     let mut hir = Hir {
         name: "test_module".to_string(),
+        comments: vec![],
         entities: vec![],
         implementations: vec![],
         protocols: vec![],
@@ -30,6 +31,7 @@ fn create_simple_entity() -> Hir {
     let entity = HirEntity {
         id: EntityId(1),
         name: "counter".to_string(),
+        comments: vec![],
         is_async: false,
         visibility: HirVisibility::Private,
         generics: vec![],
@@ -38,6 +40,7 @@ fn create_simple_entity() -> Hir {
             HirPort {
                 id: PortId(1),
                 name: "clk".to_string(),
+                comments: vec![],
                 direction: HirPortDirection::Input,
                 port_type: HirType::Clock(None),
                 physical_constraints: None,
@@ -49,6 +52,7 @@ fn create_simple_entity() -> Hir {
             HirPort {
                 id: PortId(2),
                 name: "rst".to_string(),
+                comments: vec![],
                 direction: HirPortDirection::Input,
                 port_type: HirType::Reset {
                     polarity: HirResetPolarity::ActiveHigh,
@@ -63,6 +67,7 @@ fn create_simple_entity() -> Hir {
             HirPort {
                 id: PortId(3),
                 name: "count".to_string(),
+                comments: vec![],
                 direction: HirPortDirection::Output,
                 port_type: HirType::Bit(8),
                 physical_constraints: None,
@@ -103,6 +108,7 @@ fn create_simple_entity() -> Hir {
             power_config: None,
             safety_config: None,
             power_domain: None,
+            comments: vec![],
         }],
         variables: vec![],
         constants: vec![],
@@ -123,7 +129,9 @@ fn create_simple_entity() -> Hir {
                     is_trait_op: false,
                 }),
                 assignment_type: HirAssignmentType::NonBlocking,
+                comments: vec![],
             })],
+            comments: vec![],
         }],
         assignments: vec![],
         instances: vec![],

--- a/crates/skalp-safety/src/fmea.rs
+++ b/crates/skalp-safety/src/fmea.rs
@@ -1155,6 +1155,7 @@ mod tests {
                     power_domain_config: None,
                     isolation_config: None,
                     retention_config: None,
+                    comments: vec![],
                 },
                 skalp_frontend::hir::HirPort {
                     id: skalp_frontend::hir::PortId(1),
@@ -1166,6 +1167,7 @@ mod tests {
                     power_domain_config: None,
                     isolation_config: None,
                     retention_config: None,
+                    comments: vec![],
                 },
             ],
             generics: vec![],
@@ -1180,6 +1182,7 @@ mod tests {
             safety_mechanism_config: None,
             seooc_config: None,
             compiled_ip_config: None,
+            comments: vec![],
         };
 
         let result = generator.generate_from_design(&[entity], &[], &[]);

--- a/crates/skalp-vhdl/src/hir_lower.rs
+++ b/crates/skalp-vhdl/src/hir_lower.rs
@@ -142,6 +142,29 @@ fn extract_instance_label(node: &SyntaxNode) -> Option<String> {
     })
 }
 
+/// Collect leading comments from preceding siblings of a CST node.
+/// Returns comment text with the `--` prefix stripped.
+fn collect_leading_comments(node: &SyntaxNode) -> Vec<String> {
+    let mut comments = Vec::new();
+    let mut prev = node.prev_sibling_or_token();
+    while let Some(ref element) = prev {
+        match element {
+            SyntaxElement::Token(tok) if tok.kind() == SyntaxKind::Whitespace => {
+                prev = element.prev_sibling_or_token();
+            }
+            SyntaxElement::Token(tok) if tok.kind() == SyntaxKind::Comment => {
+                let text = tok.text().to_string();
+                let stripped = text.strip_prefix("--").unwrap_or(&text).trim().to_string();
+                comments.push(stripped);
+                prev = element.prev_sibling_or_token();
+            }
+            _ => break,
+        }
+    }
+    comments.reverse();
+    comments
+}
+
 /// Collect all non-trivia token texts
 fn all_token_texts(node: &SyntaxNode) -> Vec<(SyntaxKind, String)> {
     node.children_with_tokens()
@@ -410,6 +433,7 @@ impl VhdlHirBuilder {
         Some(HirEntity {
             id,
             name: pascal_name,
+            comments: collect_leading_comments(node),
             is_async: false,
             visibility: HirVisibility::Public,
             ports,
@@ -519,6 +543,7 @@ impl VhdlHirBuilder {
             ports.push(HirPort {
                 id,
                 name: name.clone(),
+                comments: collect_leading_comments(node),
                 direction: direction.clone(),
                 port_type: port_type.clone(),
                 physical_constraints: None,
@@ -575,6 +600,7 @@ impl VhdlHirBuilder {
             ports.push(HirPort {
                 id,
                 name: flat_name,
+                comments: vec![],
                 direction,
                 port_type: field.field_type.clone(),
                 physical_constraints: None,
@@ -641,6 +667,7 @@ impl VhdlHirBuilder {
                     constants.push(HirConstant {
                         id,
                         name: generic.name.to_ascii_lowercase(),
+                        comments: vec![],
                         const_type: const_type.clone(),
                         value: default,
                     });
@@ -789,6 +816,7 @@ impl VhdlHirBuilder {
             signals.push(HirSignal {
                 id,
                 name: name.clone(),
+                comments: collect_leading_comments(node),
                 signal_type: signal_type.clone(),
                 initial_value: init.clone(),
                 clock_domain: None,
@@ -826,6 +854,7 @@ impl VhdlHirBuilder {
             var_type,
             initial_value: init,
             span: None,
+            comments: collect_leading_comments(node),
         })
     }
 
@@ -850,6 +879,7 @@ impl VhdlHirBuilder {
         Some(HirConstant {
             id,
             name,
+            comments: collect_leading_comments(node),
             const_type,
             value,
         })
@@ -944,6 +974,7 @@ impl VhdlHirBuilder {
             body,
             span: None,
             pipeline_config: None,
+            comments: collect_leading_comments(node),
         })
     }
 
@@ -965,6 +996,7 @@ impl VhdlHirBuilder {
             body,
             span: None,
             pipeline_config: None,
+            comments: collect_leading_comments(node),
         })
     }
 
@@ -1170,6 +1202,7 @@ impl VhdlHirBuilder {
             id: block_id,
             triggers,
             statements,
+            comments: collect_leading_comments(node),
         };
 
         (Some(event_block), proc_vars)
@@ -1781,6 +1814,7 @@ impl VhdlHirBuilder {
             lhs,
             assignment_type,
             rhs,
+            comments: collect_leading_comments(node),
         })
     }
 
@@ -1836,6 +1870,7 @@ impl VhdlHirBuilder {
             lhs,
             assignment_type: HirAssignmentType::Combinational,
             rhs,
+            comments: collect_leading_comments(node),
         })
     }
 
@@ -1982,6 +2017,7 @@ impl VhdlHirBuilder {
             connections,
             safety_config: None,
             variable_id: None,
+            comments: collect_leading_comments(node),
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1066,6 +1066,38 @@ fn build_design(
         info!("Using custom passes: {}", passes);
     }
 
+    // HIR-based codegen targets (skip MIR lowering)
+    match target {
+        "sk" | "skalp" => {
+            info!("Generating skalp source from HIR...");
+            let code = skalp_hir_codegen::generate_skalp_source(&hir)?;
+            fs::create_dir_all(output_dir)?;
+            let path = output_dir.join("design.sk");
+            fs::write(&path, &code)?;
+            println!("📄 Output: {:?}", path);
+            return Ok(());
+        }
+        "vhdl" => {
+            info!("Generating VHDL from HIR...");
+            let code = skalp_hir_codegen::generate_vhdl(&hir)?;
+            fs::create_dir_all(output_dir)?;
+            let path = output_dir.join("design.vhd");
+            fs::write(&path, &code)?;
+            println!("📄 Output: {:?}", path);
+            return Ok(());
+        }
+        "sv-hir" => {
+            info!("Generating SystemVerilog from HIR...");
+            let code = skalp_hir_codegen::generate_systemverilog(&hir)?;
+            fs::create_dir_all(output_dir)?;
+            let path = output_dir.join("design.sv");
+            fs::write(&path, &code)?;
+            println!("📄 Output: {:?}", path);
+            return Ok(());
+        }
+        _ => {} // fall through to MIR-based targets
+    }
+
     // Lower to MIR with CDC analysis
     info!("Lowering to MIR with CDC analysis...");
     let compiler = skalp_mir::MirCompiler::new()
@@ -1104,8 +1136,8 @@ fn build_design(
             );
         }
         "vhdl" => {
-            // VHDL generation temporarily disabled (was using legacy LIR)
-            anyhow::bail!("VHDL generation is temporarily disabled. Use 'sv' for SystemVerilog.");
+            // VHDL is now handled via HIR-based codegen above; this shouldn't be reached
+            unreachable!("VHDL target should be handled by HIR codegen path");
         }
         "lir" => {
             // LIR output temporarily disabled


### PR DESCRIPTION
## Summary

- **New crate `skalp-hir-codegen`** with three emitters that generate skalp (`.sk`), VHDL (`.vhd`), and SystemVerilog (`.sv`) directly from HIR, enabling full cross-language transpilation
- **Comment preservation pipeline** — comments are now captured as tokens in the skalp lexer, extracted from the VHDL CST, attached to HIR nodes, and emitted with the correct prefix for each target language
- **CLI integration** — `--target sk`, `--target vhdl`, and `--target sv-hir` dispatch to the new HIR-based codegen before MIR lowering; existing MIR-based SV codegen remains available via `--target sv`

## Details

### New crate: `skalp-hir-codegen` (5 files, ~2100 lines)

- `lib.rs` — `NameResolver` maps numeric HIR IDs back to names/types; public API: `generate_skalp_source()`, `generate_vhdl()`, `generate_systemverilog()`
- `skalp_emit.rs` — HIR → skalp source with full type/expression/statement coverage
- `vhdl_emit.rs` — HIR → VHDL (std_logic, process blocks, port maps, generic maps)
- `sv_emit.rs` — HIR → SystemVerilog (always_ff, module instantiation, typedef structs/enums)

### Comment preservation

- `lexer.rs` — `LineComment` and `BlockComment` tokens captured instead of skipped
- `parse.rs` — parser trivia handling reworked: `bump()` auto-skips trivia, `peek_kind()` is trivia-aware
- `hir_builder.rs` — drains pending comments and attaches to HIR nodes
- `hir.rs` — `comments: Vec<String>` added to 10 HIR node types
- `hir_lower.rs` (VHDL) — extracts leading comments from CST sibling nodes

### Parser fix

Changing comments from `logos::skip` to captured tokens introduced a regression where inline comments in expressions (e.g., inside ternary branches) caused parse errors. Fixed by making `bump()` auto-skip trivia after each consumed token and making `peek_kind()` skip over trivia when looking ahead.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace --exclude skalp-verify --exclude skalp-formal` passes with `-D warnings`
- [x] `cargo test --workspace --exclude skalp-verify --exclude skalp-formal` passes (including FP simulation tests that exercise inline comments in expressions)
- [ ] Manual smoke test: `skalp build examples/counter.sk --target sk`
- [ ] Manual smoke test: `skalp build examples/counter.sk --target vhdl`
- [ ] Manual smoke test: `skalp build examples/counter.sk --target sv-hir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>