### PR TITLE
Fix HIR codegen: dedup entities, per-entity files, range direction

### DIFF
--- a/crates/skalp-hir-codegen/src/lib.rs
+++ b/crates/skalp-hir-codegen/src/lib.rs
@@ -13,22 +13,89 @@ use skalp_frontend::hir::*;
 use std::collections::HashMap;
 use std::fmt::Write;
 
-/// Generate skalp source code from HIR
+/// A generated output file: entity name + source code
+pub struct GeneratedFile {
+    pub name: String,
+    pub code: String,
+}
+
+/// Generate skalp source code from HIR, one file per entity
+pub fn generate_skalp_files(hir: &Hir) -> Result<Vec<GeneratedFile>> {
+    let resolver = NameResolver::from_hir(hir);
+    let filtered = filter_entities(hir);
+    skalp_emit::emit_per_entity(&filtered, hir, &resolver)
+}
+
+/// Generate VHDL source code from HIR, one file per entity
+pub fn generate_vhdl_files(hir: &Hir) -> Result<Vec<GeneratedFile>> {
+    let resolver = NameResolver::from_hir(hir);
+    let filtered = filter_entities(hir);
+    vhdl_emit::emit_per_entity(&filtered, hir, &resolver)
+}
+
+/// Generate SystemVerilog source code from HIR, one file per entity
+pub fn generate_systemverilog_files(hir: &Hir) -> Result<Vec<GeneratedFile>> {
+    let resolver = NameResolver::from_hir(hir);
+    let filtered = filter_entities(hir);
+    sv_emit::emit_per_entity(&filtered, hir, &resolver)
+}
+
+/// Generate skalp source code from HIR (single string, for backward compat)
 pub fn generate_skalp_source(hir: &Hir) -> Result<String> {
-    let resolver = NameResolver::from_hir(hir);
-    skalp_emit::emit_file(hir, &resolver)
+    let files = generate_skalp_files(hir)?;
+    Ok(files
+        .into_iter()
+        .map(|f| f.code)
+        .collect::<Vec<_>>()
+        .join("\n"))
 }
 
-/// Generate VHDL source code from HIR
+/// Generate VHDL source code from HIR (single string, for backward compat)
 pub fn generate_vhdl(hir: &Hir) -> Result<String> {
-    let resolver = NameResolver::from_hir(hir);
-    vhdl_emit::emit_file(hir, &resolver)
+    let files = generate_vhdl_files(hir)?;
+    Ok(files
+        .into_iter()
+        .map(|f| f.code)
+        .collect::<Vec<_>>()
+        .join("\n"))
 }
 
-/// Generate SystemVerilog source code from HIR
+/// Generate SystemVerilog source code from HIR (single string, for backward compat)
 pub fn generate_systemverilog(hir: &Hir) -> Result<String> {
-    let resolver = NameResolver::from_hir(hir);
-    sv_emit::emit_file(hir, &resolver)
+    let files = generate_systemverilog_files(hir)?;
+    Ok(files
+        .into_iter()
+        .map(|f| f.code)
+        .collect::<Vec<_>>()
+        .join("\n"))
+}
+
+/// Filter entities: skip generic templates that have been monomorphized.
+/// An entity with non-empty generics is a template; if a concrete specialization
+/// (same name prefix + "_" suffix, empty generics) exists, skip the template.
+fn filter_entities(hir: &Hir) -> Vec<&HirEntity> {
+    let concrete_names: std::collections::HashSet<&str> = hir
+        .entities
+        .iter()
+        .filter(|e| e.generics.is_empty())
+        .map(|e| e.name.as_str())
+        .collect();
+
+    hir.entities
+        .iter()
+        .filter(|entity| {
+            if entity.generics.is_empty() {
+                // Concrete entity — always emit
+                true
+            } else {
+                // Generic template — skip if any monomorphized version exists
+                let has_specialization = concrete_names
+                    .iter()
+                    .any(|name| name.starts_with(&entity.name) && name.len() > entity.name.len());
+                !has_specialization
+            }
+        })
+        .collect()
 }
 
 /// Maps numeric IDs back to names and types for readable emission

--- a/crates/skalp-hir-codegen/src/skalp_emit.rs
+++ b/crates/skalp-hir-codegen/src/skalp_emit.rs
@@ -5,24 +5,30 @@ use anyhow::Result;
 use skalp_frontend::hir::*;
 use std::fmt::Write;
 
-pub(crate) fn emit_file(hir: &Hir, resolver: &NameResolver) -> Result<String> {
-    let mut out = String::new();
-
-    emit_comments(&mut out, &hir.comments, "//", "");
-
-    for entity in &hir.entities {
-        emit_entity(&mut out, entity, resolver);
-        writeln!(out)?;
-    }
-
-    for (i, imp) in hir.implementations.iter().enumerate() {
-        emit_impl(&mut out, imp, resolver);
-        if i + 1 < hir.implementations.len() {
-            writeln!(out)?;
-        }
-    }
-
-    Ok(out)
+pub(crate) fn emit_per_entity(
+    entities: &[&HirEntity],
+    hir: &Hir,
+    resolver: &NameResolver,
+) -> Result<Vec<crate::GeneratedFile>> {
+    entities
+        .iter()
+        .map(|entity| {
+            let mut out = String::new();
+            emit_entity(&mut out, entity, resolver);
+            if let Some(imp) = hir
+                .implementations
+                .iter()
+                .find(|imp| imp.entity == entity.id)
+            {
+                writeln!(out).unwrap();
+                emit_impl(&mut out, imp, resolver);
+            }
+            Ok(crate::GeneratedFile {
+                name: entity.name.clone(),
+                code: out,
+            })
+        })
+        .collect()
 }
 
 fn emit_entity(out: &mut String, entity: &HirEntity, resolver: &NameResolver) {
@@ -507,12 +513,12 @@ pub(crate) fn emit_expression_inline(expr: &HirExpression, resolver: &NameResolv
                 emit_expression_inline(idx, resolver)
             )
         }
-        HirExpression::Range(base, lo, hi) => {
+        HirExpression::Range(base, hi, lo) => {
             format!(
                 "{}[{}..{}]",
                 emit_expression_inline(base, resolver),
-                emit_expression_inline(lo, resolver),
-                emit_expression_inline(hi, resolver)
+                emit_expression_inline(hi, resolver),
+                emit_expression_inline(lo, resolver)
             )
         }
         HirExpression::FieldAccess { base, field } => {
@@ -753,12 +759,12 @@ fn emit_lvalue(lval: &HirLValue, resolver: &NameResolver) -> String {
                 emit_expression_inline(idx, resolver)
             )
         }
-        HirLValue::Range(base, lo, hi) => {
+        HirLValue::Range(base, hi, lo) => {
             format!(
                 "{}[{}..{}]",
                 emit_lvalue(base, resolver),
-                emit_expression_inline(lo, resolver),
-                emit_expression_inline(hi, resolver)
+                emit_expression_inline(hi, resolver),
+                emit_expression_inline(lo, resolver)
             )
         }
         HirLValue::FieldAccess { base, field } => {

--- a/crates/skalp-hir-codegen/src/sv_emit.rs
+++ b/crates/skalp-hir-codegen/src/sv_emit.rs
@@ -6,25 +6,27 @@ use anyhow::Result;
 use skalp_frontend::hir::*;
 use std::fmt::Write;
 
-pub(crate) fn emit_file(hir: &Hir, resolver: &NameResolver) -> Result<String> {
-    let mut out = String::new();
-
-    emit_comments(&mut out, &hir.comments, "//", "");
-
-    for (i, entity) in hir.entities.iter().enumerate() {
-        // Find matching implementation
-        let imp = hir
-            .implementations
-            .iter()
-            .find(|imp| imp.entity == entity.id);
-        emit_module(&mut out, entity, imp, resolver);
-
-        if i + 1 < hir.entities.len() {
-            writeln!(out).unwrap();
-        }
-    }
-
-    Ok(out)
+pub(crate) fn emit_per_entity(
+    entities: &[&HirEntity],
+    hir: &Hir,
+    resolver: &NameResolver,
+) -> Result<Vec<crate::GeneratedFile>> {
+    entities
+        .iter()
+        .map(|entity| {
+            let mut out = String::new();
+            emit_comments(&mut out, &entity.comments, "//", "");
+            let imp = hir
+                .implementations
+                .iter()
+                .find(|imp| imp.entity == entity.id);
+            emit_module(&mut out, entity, imp, resolver);
+            Ok(crate::GeneratedFile {
+                name: entity.name.clone(),
+                code: out,
+            })
+        })
+        .collect()
 }
 
 fn emit_module(
@@ -458,7 +460,7 @@ fn emit_expr(expr: &HirExpression, resolver: &NameResolver) -> String {
                 emit_expr(idx, resolver)
             )
         }
-        HirExpression::Range(base, lo, hi) => {
+        HirExpression::Range(base, hi, lo) => {
             format!(
                 "{}[{}:{}]",
                 emit_expr(base, resolver),
@@ -617,7 +619,7 @@ fn emit_lvalue(lval: &HirLValue, resolver: &NameResolver) -> String {
                 emit_expr(idx, resolver)
             )
         }
-        HirLValue::Range(base, lo, hi) => {
+        HirLValue::Range(base, hi, lo) => {
             format!(
                 "{}[{}:{}]",
                 emit_lvalue(base, resolver),

--- a/crates/skalp-hir-codegen/src/vhdl_emit.rs
+++ b/crates/skalp-hir-codegen/src/vhdl_emit.rs
@@ -6,36 +6,36 @@ use anyhow::Result;
 use skalp_frontend::hir::*;
 use std::fmt::Write;
 
-pub(crate) fn emit_file(hir: &Hir, resolver: &NameResolver) -> Result<String> {
-    let mut out = String::new();
-
-    emit_comments(&mut out, &hir.comments, "--", "");
-
-    // IEEE library preamble
-    writeln!(out, "library ieee;")?;
-    writeln!(out, "use ieee.std_logic_1164.all;")?;
-    writeln!(out, "use ieee.numeric_std.all;")?;
-    writeln!(out)?;
-
-    for (i, entity) in hir.entities.iter().enumerate() {
-        emit_entity(&mut out, entity, resolver);
-
-        // Find matching implementation
-        if let Some(imp) = hir
-            .implementations
-            .iter()
-            .find(|imp| imp.entity == entity.id)
-        {
+pub(crate) fn emit_per_entity(
+    entities: &[&HirEntity],
+    hir: &Hir,
+    resolver: &NameResolver,
+) -> Result<Vec<crate::GeneratedFile>> {
+    entities
+        .iter()
+        .map(|entity| {
+            let mut out = String::new();
+            // IEEE library preamble
+            writeln!(out, "library ieee;").unwrap();
+            writeln!(out, "use ieee.std_logic_1164.all;").unwrap();
+            writeln!(out, "use ieee.numeric_std.all;").unwrap();
             writeln!(out).unwrap();
-            emit_architecture(&mut out, imp, entity, resolver);
-        }
-
-        if i + 1 < hir.entities.len() {
-            writeln!(out).unwrap();
-        }
-    }
-
-    Ok(out)
+            emit_comments(&mut out, &entity.comments, "--", "");
+            emit_entity(&mut out, entity, resolver);
+            if let Some(imp) = hir
+                .implementations
+                .iter()
+                .find(|imp| imp.entity == entity.id)
+            {
+                writeln!(out).unwrap();
+                emit_architecture(&mut out, imp, entity, resolver);
+            }
+            Ok(crate::GeneratedFile {
+                name: entity.name.clone(),
+                code: out,
+            })
+        })
+        .collect()
 }
 
 fn emit_entity(out: &mut String, entity: &HirEntity, resolver: &NameResolver) {
@@ -446,7 +446,7 @@ fn emit_expr(expr: &HirExpression, resolver: &NameResolver) -> String {
                 emit_expr(idx, resolver)
             )
         }
-        HirExpression::Range(base, lo, hi) => {
+        HirExpression::Range(base, hi, lo) => {
             format!(
                 "{}({} downto {})",
                 emit_expr(base, resolver),
@@ -605,7 +605,7 @@ fn emit_lvalue(lval: &HirLValue, resolver: &NameResolver) -> String {
                 emit_expr(idx, resolver)
             )
         }
-        HirLValue::Range(base, lo, hi) => {
+        HirLValue::Range(base, hi, lo) => {
             format!(
                 "{}({} downto {})",
                 emit_lvalue(base, resolver),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1070,29 +1070,35 @@ fn build_design(
     match target {
         "sk" | "skalp" => {
             info!("Generating skalp source from HIR...");
-            let code = skalp_hir_codegen::generate_skalp_source(&hir)?;
+            let files = skalp_hir_codegen::generate_skalp_files(&hir)?;
             fs::create_dir_all(output_dir)?;
-            let path = output_dir.join("design.sk");
-            fs::write(&path, &code)?;
-            println!("📄 Output: {:?}", path);
+            for file in &files {
+                let path = output_dir.join(format!("{}.sk", file.name.to_lowercase()));
+                fs::write(&path, &file.code)?;
+                println!("📄 Output: {:?}", path);
+            }
             return Ok(());
         }
         "vhdl" => {
             info!("Generating VHDL from HIR...");
-            let code = skalp_hir_codegen::generate_vhdl(&hir)?;
+            let files = skalp_hir_codegen::generate_vhdl_files(&hir)?;
             fs::create_dir_all(output_dir)?;
-            let path = output_dir.join("design.vhd");
-            fs::write(&path, &code)?;
-            println!("📄 Output: {:?}", path);
+            for file in &files {
+                let path = output_dir.join(format!("{}.vhd", file.name.to_lowercase()));
+                fs::write(&path, &file.code)?;
+                println!("📄 Output: {:?}", path);
+            }
             return Ok(());
         }
         "sv-hir" => {
             info!("Generating SystemVerilog from HIR...");
-            let code = skalp_hir_codegen::generate_systemverilog(&hir)?;
+            let files = skalp_hir_codegen::generate_systemverilog_files(&hir)?;
             fs::create_dir_all(output_dir)?;
-            let path = output_dir.join("design.sv");
-            fs::write(&path, &code)?;
-            println!("📄 Output: {:?}", path);
+            for file in &files {
+                let path = output_dir.join(format!("{}.sv", file.name.to_lowercase()));
+                fs::write(&path, &file.code)?;
+                println!("📄 Output: {:?}", path);
+            }
             return Ok(());
         }
         _ => {} // fall through to MIR-based targets


### PR DESCRIPTION
## Summary

Three quality fixes for the HIR-based transpiler:

- **Deduplicate entities** — generic templates (e.g. `Adder<WIDTH>`) are now filtered out when monomorphized versions (e.g. `Adder_32`) exist, eliminating duplicate module definitions
- **Per-entity file output** — each entity gets its own file (`adder_32.sv`, `comparator_32.sv`, etc.) instead of one monolithic `design.sv`
- **Fix range direction** — `result[0:31]` is now correctly `result[31:0]` in SV, `result(31 downto 0)` in VHDL. The HIR stores `Range(base, hi, lo)` but emitters had the destructured variable names swapped.

## Before / After

**Before:** `skalp build --source examples/hierarchical_alu.sk --target sv-hir`
```
build/design.sv  (single file, 8 modules including duplicates)
  - Adder<WIDTH>, Adder_32, Comparator<WIDTH>, Comparator_32, ...
  - result[0:31]  (wrong direction)
```

**After:**
```
build/adder_32.sv
build/comparator_32.sv
build/shifter_32.sv
build/hierarchicalalu_32.sv
  - result[31:0]  (correct direction)
```

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --workspace` passes
- [x] `cargo test --workspace` passes
- [x] CLI integration tests pass
- [x] Hierarchical ALU produces correct per-entity SV/VHDL/skalp output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>